### PR TITLE
chore: add ci bot to bypass branch protection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,17 +28,30 @@ jobs:
       commit_sha: ${{ steps.get-commit.outputs.commit_sha }}
 
     steps:
+      - name: Setup | Get CI Bot Token
+        uses: tibdex/github-app-token@v1
+        id: ci_bot_token
+        with:
+          app_id: ${{ secrets.CI_BOT_APP_ID }}
+          private_key: ${{ secrets.CI_BOT_SECRET }}
+
       - name: Setup | Checkout Repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
+          token: ${{ steps.ci_bot_token.outputs.token }}
 
       - name: Check | Verify Upstream Unchanged
         shell: bash
         run: |
           chmod +x scripts/verify-upstream.sh
           ./scripts/verify-upstream.sh ${{ github.sha }}
+
+      - name: Setup | Initialize Git User
+        run: |
+          git config --global user.email "github-actions[bot]@genlayerlabs.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Setup | Install Python
         uses: actions/setup-python@v5
@@ -53,7 +66,7 @@ jobs:
       - name: Action | Semantic Version Release
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.ci_bot_token.outputs.token }}
         run: |
           chmod +x scripts/semantic-version-release.sh
           ./scripts/semantic-version-release.sh releaserc.toml


### PR DESCRIPTION
Fixes DXP-502

## What

- Added CI bot to bypass branch protection in main branch

## Why

- To fix release workflow after a merged PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to improve authentication and configure Git user information.
  * Disabled the step that publishes packages to PyPI.
  * Expanded release configuration to include an additional branch for release processing.
* **New Features**
  * Released version 1.0.0 with redesigned method handling, statistical prompt testing, and CLI support for artifact management.
* **Bug Fixes**
  * Improved client selection by prioritizing the default client.
* **Documentation**
  * Updated documentation to reflect breaking changes.
* **Refactor**
  * Removed a component to enhance modularity.
* **Tests**
  * Refreshed test examples and added CLI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->