### PR TITLE
docs: update contributing guide with uv development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,23 +35,21 @@ Have ideas for new features or use cases? We're eager to hear them! But first:
 
 - **1.2. Create a branch**: create the branch that you will work on by using the link provided in the issue details page (right panel at the bottom - section "Development")
 
-- **1.3. Setup the package locally**: clone the repository
+- **1.3. Setup the package locally**: clone the repository and install dependencies
 
    ```sh
    $ git clone https://github.com/genlayerlabs/genlayer-testing-suite.git
+   $ cd genlayer-testing-suite
+   $ uv sync
    ```
 
-- **1.4. Add the package to your project locally**: to add the package locally, use the command:
-  - **Option 1:** Install the package in regular mode
-      ```sh
-      $ pip install path/to/genlayer-testing-suite
-      ```
-  - **Option 2:** Install the package in editable mode
+   You can then run tests with:
 
-      ```sh
-      $ pip install -e path/to/genlayer-testing-suite --config-settings editable_mode=strict
-      ```
-   This will allow you to use the package in your project without publishing it. With option 1 you need to re-install the package on every changes you make and with option 2 you only need to perform a re-installation if you change the project metadata. You can find more information in the pip [documentation](https://pip.pypa.io/en/stable/topics/local-project-installs/)
+   ```sh
+   $ uv run gltest
+   ```
+
+   > **Note**: This project uses [uv](https://docs.astral.sh/uv/) for dependency management. If you don't have it installed, see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 
 #### 2. Submit your solution


### PR DESCRIPTION
## Summary
- Replace outdated pip-based dev setup instructions in CONTRIBUTING.md with uv commands (`uv sync`, `uv run gltest`)
- Add a note linking to the uv installation guide for new contributors

## Test plan
- [ ] Verify the CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify `uv sync` and `uv run gltest` work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified contribution setup process with streamlined installation instructions
  * Updated testing workflow with new commands for running tests
  * Enhanced setup guidance with explicit steps for cloning the repository and installing dependencies
  * Added references to dependency management documentation for contributors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->