### PR TITLE
fix: replace broken Discord badge image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GenLayer Testing Suite
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/license/mit/)
-[![Discord](https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat)](https://discord.gg/qjCU4AWnKE)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289da?logo=discord&logoColor=white)](https://discord.gg/qjCU4AWnKE)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/genlayerlabs.svg?style=social&label=Follow%20%40GenLayer)](https://x.com/GenLayer)
 [![PyPI version](https://badge.fury.io/py/genlayer-test.svg)](https://badge.fury.io/py/genlayer-test)
 [![Documentation](https://img.shields.io/badge/docs-genlayer-blue)](https://docs.genlayer.com/api-references/genlayer-test)


### PR DESCRIPTION
## Summary
- Replaced the broken Discord badge (`dcbadge.vercel.app`) with a shields.io badge that renders correctly
- The Discord invite link remains unchanged

## Test plan
- [ ] Verify the Discord badge renders correctly on the GitHub README page
- [ ] Verify the badge links to the correct Discord invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Discord community badge styling in project documentation for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->