### PR TITLE
feat(gltest): add testnet_bradbury to preconfigured networks

### DIFF
--- a/gltest_cli/config/constants.py
+++ b/gltest_cli/config/constants.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 GLTEST_CONFIG_FILE = "gltest.config.yaml"
 DEFAULT_NETWORK = "localnet"
-PRECONFIGURED_NETWORKS = ["localnet", "studionet", "testnet_asimov"]
-CHAINS = ["localnet", "studionet", "testnet_asimov"]
+PRECONFIGURED_NETWORKS = ["localnet", "studionet", "testnet_asimov", "testnet_bradbury"]
+CHAINS = ["localnet", "studionet", "testnet_asimov", "testnet_bradbury"]
 DEFAULT_RPC_URL = SIMULATOR_JSON_RPC_URL
 DEFAULT_ENVIRONMENT = ".env"
 DEFAULT_CONTRACTS_DIR = Path("contracts")

--- a/gltest_cli/config/plugin.py
+++ b/gltest_cli/config/plugin.py
@@ -89,10 +89,10 @@ def pytest_configure(config):
             )
             user_config = get_default_user_config()
 
-            # Special handling for testnet_asimov - check if accounts are configured
-            if network_name == "testnet_asimov":
+            # Special handling for remote testnets - check if accounts are configured
+            if network_name in ("testnet_asimov", "testnet_bradbury"):
                 logger.error(
-                    "For testnet_asimov, you need to configure accounts in gltest.config.yaml, see https://docs.genlayer.com/api-references/genlayer-test"
+                    f"For {network_name}, you need to configure accounts in gltest.config.yaml, see https://docs.genlayer.com/api-references/genlayer-test"
                 )
                 pytest.exit("gltest configuration error")
         else:

--- a/gltest_cli/config/types.py
+++ b/gltest_cli/config/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
-from genlayer_py.chains import localnet, studionet, testnet_asimov
+from genlayer_py.chains import localnet, studionet, testnet_asimov, testnet_bradbury
 from genlayer_py.types import GenLayerChain
 from gltest_cli.config.constants import PRECONFIGURED_NETWORKS
 from gltest_cli.config.constants import (
@@ -189,6 +189,7 @@ class GeneralConfig:
             "localnet": localnet,
             "studionet": studionet,
             "testnet_asimov": testnet_asimov,
+            "testnet_bradbury": testnet_bradbury,
         }
         chain_type = self.get_chain_type()
         return chain_map[chain_type]

--- a/gltest_cli/config/user.py
+++ b/gltest_cli/config/user.py
@@ -18,7 +18,7 @@ from gltest_cli.config.constants import (
     DEFAULT_LEADER_ONLY,
     CHAINS,
 )
-from genlayer_py.chains import localnet, studionet, testnet_asimov
+from genlayer_py.chains import localnet, studionet, testnet_asimov, testnet_bradbury
 from gltest_cli.config.types import UserConfig, NetworkConfigData, PathConfig
 
 VALID_ROOT_KEYS = ["networks", "paths", "environment"]
@@ -70,6 +70,16 @@ def get_default_user_config() -> UserConfig:
             default_wait_interval=DEFAULT_WAIT_INTERVAL,
             default_wait_retries=DEFAULT_WAIT_RETRIES,
             chain_type="testnet_asimov",
+        ),
+        "testnet_bradbury": NetworkConfigData(
+            id=testnet_bradbury.id,
+            url=testnet_bradbury.rpc_urls["default"]["http"][0],
+            accounts=None,
+            from_account=None,
+            leader_only=DEFAULT_LEADER_ONLY,
+            default_wait_interval=DEFAULT_WAIT_INTERVAL,
+            default_wait_retries=DEFAULT_WAIT_RETRIES,
+            chain_type="testnet_bradbury",
         ),
     }
 
@@ -176,7 +186,7 @@ def validate_network_config(network_name: str, network_config: dict):
             raise ValueError(f"network {network_name} must have accounts")
         if "chain_type" not in network_config:
             raise ValueError(
-                f"network {network_name} must have a chain_type. Valid values: localnet, studionet, testnet_asimov"
+                f"network {network_name} must have a chain_type. Valid values: {', '.join(CHAINS)}"
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py==0.9.0",
+    "genlayer-py>=0.11.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.11.0",
+    "genlayer-py>=0.11.0,<0.12.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"

--- a/tests/gltest_cli/config/test_plugin.py
+++ b/tests/gltest_cli/config/test_plugin.py
@@ -20,7 +20,7 @@ def test_help_message(pytester):
             "  --leader-only         Run contracts in leader-only mode",
             "  --chain-type=CHAIN_TYPE",
             "                        Chain type (possible values: localnet, studionet,",
-            "                        testnet_asimov)",
+            "                        testnet_asimov, testnet_bradbury)",
         ]
     )
 
@@ -346,7 +346,7 @@ def test_chain_none_default(pytester):
             assert general_config.plugin_config.chain_type is None
             # get_chain_type should still work using network config
             chain_type = general_config.get_chain_type()
-            assert chain_type in ["localnet", "studionet", "testnet_asimov"]
+            assert chain_type in ["localnet", "studionet", "testnet_asimov", "testnet_bradbury"]
     """
     )
 

--- a/tests/gltest_cli/config/test_plugin.py
+++ b/tests/gltest_cli/config/test_plugin.py
@@ -129,6 +129,25 @@ def test_network_testnet(pytester):
     assert result.ret != 0
 
 
+def test_network_testnet_bradbury(pytester):
+    pytester.makepyfile(
+        """
+        from gltest_cli.config.general import get_general_config
+
+        def test_network():
+            general_config = get_general_config()
+            assert general_config.get_network_name() == "testnet_bradbury"
+    """
+    )
+
+    result = pytester.runpytest(
+        "--network=testnet_bradbury", "--rpc-url=http://test.example.com:9151", "-v"
+    )
+
+    # The test should exit with an error code when testnet_bradbury is used without accounts
+    assert result.ret != 0
+
+
 def test_artifacts_dir(pytester):
     """Test that artifacts directory CLI parameter works correctly."""
     pytester.makepyfile(


### PR DESCRIPTION
## Summary
- Register GenLayer Bradbury testnet (`https://rpc-bradbury.genlayer.com`, chain id 4221) as a preconfigured gltest network, same way `testnet_asimov` is today.
- `gltest --network testnet_bradbury` and `--chain-type testnet_bradbury` now route against the live Bradbury RPC via the chain definition that's already shipped in `genlayer-py` 0.11.0+.
- Bumps the `genlayer-py` pin from `==0.9.0` to `>=0.11.0` (the first version that exports `testnet_bradbury`).

## Why
Downstream projects (Rally) want to run real, non-mocked IC integration tests against Bradbury. Today gltest only knows about `localnet` / `studionet` / `testnet_asimov`, so Bradbury needs manual `gltest.config.yaml` scaffolding for every repo. Adding it to `PRECONFIGURED_NETWORKS` makes it a one-flag flip.

## Changes
- `gltest_cli/config/constants.py`: append `testnet_bradbury` to `PRECONFIGURED_NETWORKS` and `CHAINS`.
- `gltest_cli/config/user.py`: import `testnet_bradbury` and add the default network entry (no accounts by default, same as asimov — callers supply their own keys).
- `gltest_cli/config/types.py`: add `testnet_bradbury` to `GeneralConfig.get_chain()`'s `chain_map`.
- `pyproject.toml`: `genlayer-py==0.9.0` → `genlayer-py>=0.11.0`.
- `tests/gltest_cli/config/test_plugin.py`: update help-output assertion and the `chain_type in [...]` allowed-values list.

Note: Bradbury and Asimov both report chain id `4221` in `genlayer-py` — this is intentional per the upstream chain definitions, not a bug.

## Test plan
- [x] `pytest tests/gltest_cli/config/ -q` — 67/67 passing locally
- [x] Smoke check: `GeneralConfig` with `default_network='testnet_bradbury'` resolves to the real chain object (id 4221, rpc `https://rpc-bradbury.genlayer.com`)
- [ ] CI green
- [ ] Downstream smoke from Rally: `gltest --network testnet_bradbury` hits live Bradbury RPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the `testnet_bradbury` network, expanding available test network options for configuration and testing.

* **Chores**
  * Updated `genlayer-py` dependency requirement to version 0.11.0 or later for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->