### PR TITLE
fix(gltest): bump genlayer-py to >=0.12.1 for Bradbury RPC fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.11.0,<0.12.0",
+    "genlayer-py>=0.12.1,<0.13.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"


### PR DESCRIPTION
## Summary
Follow-up to #74. `genlayer-py==0.11.0` (the first version exporting `testnet_bradbury`) shipped the chain definition with the wrong RPC URL — it pointed at `https://zksync-os-testnet-genlayer.zksync.dev` (Asimov's endpoint) instead of `https://rpc-bradbury.genlayer.com`.

Upstream fix is in `genlayer-py==0.12.1` (genlayerlabs/genlayer-py@496cd07 "fix: use HTTPS domain RPC URLs for testnets"). Bumping the pin from `>=0.11.0,<0.12.0` to `>=0.12.1,<0.13.0` so `gltest --network testnet_bradbury` actually talks to Bradbury.

## Test plan
- [x] `pytest tests/gltest_cli/config/ -q` → 68/68 green locally
- [x] After bump, importing `testnet_bradbury` yields `rpc_urls["default"]["http"][0] == "https://rpc-bradbury.genlayer.com"`
- [ ] CI green