### PR TITLE
fix(gltest): widen genlayer-py to >=0.13.0,<0.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.12.1,<0.13.0",
+    "genlayer-py>=0.13.0,<0.17.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"


### PR DESCRIPTION
## Summary
Follow-up to #74/#75. Two Bradbury-specific fixes landed in `genlayer-py` v0.13.0 that downstream consumers hit immediately on first contact:

1. **Cloudflare bypass**: `genlayer-py@31412c9` ("feat: Expose tx_execution_result…") added `"User-Agent": "genlayer-py"` to the `GenLayerProvider` POST headers. Without it, every RPC call to `rpc-bradbury.genlayer.com` returns a `Just a moment...` challenge page — Cloudflare blocks the default `python-requests/X.Y.Z` UA. Verified live: curl with any non-default UA returns `200`; `requests` with its default UA returns `403 + CF challenge`.
2. **Bradbury V06 receipt decoding**: `wait_for_transaction_receipt` raises a bytes-as-string error on Bradbury txs with `genlayer-py==0.12.1`. Same flow works cleanly on `0.16.3` (tested against a live deploy on Bradbury — tx `0xbfe6867f…`).

Both fixes are gated behind the current `<0.13.0` cap from #75. Bumping to `>=0.13.0,<0.17.0` covers the whole current released line (0.16.3 is latest) with an explicit upper bound, as CodeRabbit suggested on #74.

## Test plan
- [x] `pytest tests/gltest_cli/config/ -q` → 68/68 green locally
- [x] With `genlayer-py 0.16.3`, `wait_for_transaction_receipt` against a live Bradbury tx returns a structured receipt (`status_name: ACCEPTED`, full `last_round` + validator set)
- [x] Cloudflare no longer blocks Rally's `gltest --network testnet_bradbury` invocations
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `genlayer-py` dependency to support versions 0.13.0 through 0.16.x, expanding compatibility with the latest upstream releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->