### PR TITLE
ci: scope down release/sync-docs to dedicated GitHub Apps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
     name: Release and Upload Artifacts
     runs-on: ubuntu-latest
     needs: run-tests
+    environment: Publish
 
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
@@ -29,11 +30,11 @@ jobs:
 
     steps:
       - name: Setup | Get CI Bot Token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: ci_bot_token
         with:
-          app_id: ${{ secrets.CI_BOT_APP_ID }}
-          private_key: ${{ secrets.CI_BOT_SECRET }}
+          client-id: ${{ vars.PUBLISH_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUBLISH_CI_APP_KEY }}
 
       - name: Setup | Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -9,6 +9,7 @@ jobs:
   generate-and-sync:
     if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-')
     runs-on: ubuntu-latest
+    environment: Sync-docs
     permissions:
       contents: read
     steps:
@@ -37,9 +38,9 @@ jobs:
 
       - name: Generate docs repo token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOCS_SYNC_APP_ID }}
+          client-id: ${{ vars.DOCS_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_SYNC_APP_KEY }}
           repositories: genlayer-docs
 


### PR DESCRIPTION
## Summary

Reduce the attack surface of the release pipeline by replacing the shared, over-privileged CI bot with two dedicated, minimally scoped GitHub Apps gated behind protected environments.

The previous setup used a single shared App with read+write across ~30 permission categories on all org repositories. The two App tokens issued from CI workflows are now narrowly scoped:

- **`publish.yml`** — moved under the `Publish` environment, switched from the archived `tibdex/github-app-token@v1` to the official `actions/create-github-app-token@v3`. Reads `vars.PUBLISH_CI_APP_CLIENT_ID` and `secrets.PUBLISH_CI_APP_KEY`.
- **`sync-docs.yml`** — bumped `actions/create-github-app-token` to `@v3`, switched to the explicit `client-id` parameter, gated behind the `Sync-docs` environment. Reads `vars.DOCS_SYNC_APP_CLIENT_ID` and `secrets.DOCS_SYNC_APP_KEY`. Cross-repo `repositories: genlayer-docs` token request is preserved.

Each App should be installed only on the repos it needs (Publish: this repo only; Sync-docs: this repo + `genlayer-docs`) with `Contents: Read & write` as the only permission.

## Pre-merge checklist (GitHub side)

- [x] `Publish` environment exists with `PUBLISH_CI_APP_CLIENT_ID` (variable) and `PUBLISH_CI_APP_KEY` (secret)
- [x] `Sync-docs` environment exists with `DOCS_SYNC_APP_CLIENT_ID` (variable) and `DOCS_SYNC_APP_KEY` (secret)
- [x] Both Apps installed on `genlayer-testing-suite` (sync-docs App also on `genlayer-docs`) with only `Contents: Read & write`
- [x] `Publish` App added to branch-protection bypass list on `main` (semantic-release pushes the version-bump commit + tag)

## Test plan

- [ ] Land a `fix:` or `feat:` commit on `main` after merge and confirm `publish.yml` mints a token, semantic-release pushes the version bump + tag, the GitHub Release is created, and PyPI upload succeeds
- [ ] Confirm `sync-docs.yml` fires automatically on `release: published` and pushes the API-reference update PR/commit to `genlayer-docs`
- [ ] Once verified, decommission the old shared CI App from this repo and rotate / revoke its secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the latest GitHub App token action with new configuration parameters for improved automation in release publishing and documentation synchronization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->