### PR TITLE
fix: support current GenVM bundle artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,7 @@ jobs:
 
       - name: Action | Run gltest tests
         run: uv run gltest tests/gltest/
+
+      # Unit tests only — integration tests here download the GenVM SDK.
+      - name: Action | Run direct runner unit tests
+        run: uv run gltest tests/gltest_direct/test_sdk_loader.py

--- a/gltest/direct/sdk_loader.py
+++ b/gltest/direct/sdk_loader.py
@@ -11,12 +11,19 @@ import sys
 import json
 import tarfile
 import tempfile
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Optional, Dict, List
 
 CACHE_DIR = Path.home() / ".cache" / "gltest-direct"
 GITHUB_RELEASES_URL = "https://github.com/genlayerlabs/genvm/releases"
+GITHUB_API_RELEASES = "https://api.github.com/repos/genlayerlabs/genvm/releases"
+
+# GenVM 0.3.0 renamed this bundle from genvm-universal.tar.xz; newest name first.
+RUNNER_BUNDLE_ASSETS = ("genvm-runners-all.tar.xz", "genvm-universal.tar.xz")
+GENVM_VERSION_ENV = "GENVM_VERSION"
+FALLBACK_VERSION = "v0.2.16"
 
 RUNNER_TYPE = "py-genlayer"
 STD_LIB_TYPE = "py-lib-genlayer-std"
@@ -43,23 +50,50 @@ def parse_contract_header(contract_path: Path) -> Dict[str, str]:
 
 
 def get_latest_version() -> str:
-    """Get latest genvm release version from GitHub."""
+    """Newest non-prerelease GenVM release that ships a known runner bundle."""
     try:
         req = urllib.request.Request(
-            f"{GITHUB_RELEASES_URL}/latest",
-            method="HEAD",
+            f"{GITHUB_API_RELEASES}?per_page=100",
+            headers={
+                "User-Agent": "gltest-direct",
+                "Accept": "application/vnd.github+json",
+            },
         )
-        req.add_header("User-Agent", "gltest-direct")
         with urllib.request.urlopen(req, timeout=10) as resp:
-            final_url = resp.url
-            version = final_url.split("/")[-1]
-            return version
-    except Exception:
-        return "v0.2.12"
+            releases = json.loads(resp.read().decode("utf-8"))
+        for release in releases:
+            if release.get("prerelease") or release.get("draft"):
+                continue
+            asset_names = {asset.get("name") for asset in release.get("assets", [])}
+            if asset_names.intersection(RUNNER_BUNDLE_ASSETS):
+                return release["tag_name"]
+    except Exception as exc:
+        print(
+            f"Warning: could not resolve latest GenVM version ({exc}); "
+            f"falling back to {FALLBACK_VERSION}",
+            file=sys.stderr,
+        )
+    return FALLBACK_VERSION
+
+
+def resolve_version() -> str:
+    """GenVM version to use: GENVM_VERSION env var > newest cached > latest release."""
+    pinned = os.environ.get(GENVM_VERSION_ENV)
+    if pinned:
+        return pinned
+    cached = list_cached_versions()
+    if cached:
+        return cached[0]
+    return get_latest_version()
+
+
+def _version_sort_key(version: str) -> tuple:
+    """Numeric-component sort key so v0.2.16 ranks above v0.2.9."""
+    return tuple(int(n) for n in re.findall(r"\d+", version))
 
 
 def list_cached_versions() -> List[str]:
-    """List all cached genvm versions."""
+    """List all cached genvm versions, newest first."""
     if not CACHE_DIR.exists():
         return []
 
@@ -68,20 +102,11 @@ def list_cached_versions() -> List[str]:
         match = re.search(r"genvm-universal-(.+)\.tar\.xz", f.name)
         if match:
             versions.append(match.group(1))
-    return sorted(versions, reverse=True)
+    return sorted(versions, key=_version_sort_key, reverse=True)
 
 
-def download_artifacts(version: str) -> Path:
-    """Download genvm release tarball if not cached."""
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
-
-    tarball_name = f"genvm-universal-{version}.tar.xz"
-    tarball_path = CACHE_DIR / tarball_name
-
-    if tarball_path.exists():
-        return tarball_path
-
-    url = f"{GITHUB_RELEASES_URL}/download/{version}/genvm-universal.tar.xz"
+def _download_to(url: str, dest: Path) -> None:
+    """Stream url to dest, replacing it atomically on success."""
     print(f"Downloading {url}...")
 
     req = urllib.request.Request(url)
@@ -105,8 +130,32 @@ def download_artifacts(version: str) -> Path:
             tmp_path = tmp.name
 
     print()
-    os.rename(tmp_path, tarball_path)
-    return tarball_path
+    os.rename(tmp_path, dest)
+
+
+def download_artifacts(version: str) -> Path:
+    """Download the GenVM runner bundle for version if not cached."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    tarball_path = CACHE_DIR / f"genvm-universal-{version}.tar.xz"
+    if tarball_path.exists():
+        return tarball_path
+
+    last_error: Optional[Exception] = None
+    for asset in RUNNER_BUNDLE_ASSETS:
+        url = f"{GITHUB_RELEASES_URL}/download/{version}/{asset}"
+        try:
+            _download_to(url, tarball_path)
+            return tarball_path
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                last_error = e
+                continue
+            raise
+
+    raise FileNotFoundError(
+        f"No GenVM runner bundle for {version}; tried {', '.join(RUNNER_BUNDLE_ASSETS)}"
+    ) from last_error
 
 
 def extract_runner(
@@ -208,8 +257,7 @@ def setup_sdk_paths(
         contract_deps = parse_contract_header(contract_path)
 
     if version is None:
-        cached = list_cached_versions()
-        version = cached[0] if cached else get_latest_version()
+        version = resolve_version()
 
     tarball = download_artifacts(version)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.13.0,<0.17.0",
+    "genlayer-py>=0.18.0,<0.19.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"

--- a/tests/gltest_direct/test_sdk_loader.py
+++ b/tests/gltest_direct/test_sdk_loader.py
@@ -1,0 +1,200 @@
+"""Unit tests for direct-runner GenVM version and artifact resolution."""
+
+import json
+import urllib.error
+
+from gltest.direct import sdk_loader
+
+
+class _FakeResponse:
+    """Minimal context-manager stand-in for urllib's HTTP response."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+class TestResolveVersion:
+    """resolve_version() precedence: env var > cache > latest release."""
+
+    def test_env_var_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv(sdk_loader.GENVM_VERSION_ENV, "v1.2.3")
+        monkeypatch.setattr(sdk_loader, "list_cached_versions", lambda: ["v0.2.16"])
+        monkeypatch.setattr(sdk_loader, "get_latest_version", lambda: "v0.9.9")
+
+        assert sdk_loader.resolve_version() == "v1.2.3"
+
+    def test_falls_back_to_newest_cached_version(self, monkeypatch):
+        monkeypatch.delenv(sdk_loader.GENVM_VERSION_ENV, raising=False)
+        monkeypatch.setattr(sdk_loader, "list_cached_versions", lambda: ["v0.2.16"])
+        monkeypatch.setattr(sdk_loader, "get_latest_version", lambda: "v0.9.9")
+
+        assert sdk_loader.resolve_version() == "v0.2.16"
+
+    def test_falls_back_to_latest_when_no_cache(self, monkeypatch):
+        monkeypatch.delenv(sdk_loader.GENVM_VERSION_ENV, raising=False)
+        monkeypatch.setattr(sdk_loader, "list_cached_versions", lambda: [])
+        monkeypatch.setattr(sdk_loader, "get_latest_version", lambda: "v0.9.9")
+
+        assert sdk_loader.resolve_version() == "v0.9.9"
+
+
+class TestGetLatestVersion:
+    """get_latest_version() skips pre-releases and assetless releases."""
+
+    def test_skips_releases_without_a_bundle_asset(self, monkeypatch):
+        releases = [
+            {
+                "tag_name": "v0.9.9",
+                "prerelease": False,
+                "assets": [{"name": "genvm-linux-amd64.tar.xz"}],
+            },
+            {
+                "tag_name": "v0.2.16",
+                "prerelease": False,
+                "assets": [{"name": "genvm-universal.tar.xz"}],
+            },
+        ]
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **k: _FakeResponse(releases)
+        )
+
+        assert sdk_loader.get_latest_version() == "v0.2.16"
+
+    def test_accepts_renamed_runners_all_asset(self, monkeypatch):
+        releases = [
+            {
+                "tag_name": "v0.3.0",
+                "prerelease": False,
+                "assets": [{"name": "genvm-runners-all.tar.xz"}],
+            },
+            {
+                "tag_name": "v0.2.16",
+                "prerelease": False,
+                "assets": [{"name": "genvm-universal.tar.xz"}],
+            },
+        ]
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **k: _FakeResponse(releases)
+        )
+
+        assert sdk_loader.get_latest_version() == "v0.3.0"
+
+    def test_skips_prereleases(self, monkeypatch):
+        releases = [
+            {
+                "tag_name": "v0.3.0-rc0",
+                "prerelease": True,
+                "assets": [{"name": "genvm-runners-all.tar.xz"}],
+            },
+            {
+                "tag_name": "v0.2.16",
+                "prerelease": False,
+                "assets": [{"name": "genvm-universal.tar.xz"}],
+            },
+        ]
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **k: _FakeResponse(releases)
+        )
+
+        assert sdk_loader.get_latest_version() == "v0.2.16"
+
+    def test_returns_fallback_when_api_unreachable(self, monkeypatch, capsys):
+        def _boom(*a, **k):
+            raise OSError("network down")
+
+        monkeypatch.setattr("urllib.request.urlopen", _boom)
+
+        assert sdk_loader.get_latest_version() == sdk_loader.FALLBACK_VERSION
+        assert "could not resolve latest GenVM version" in capsys.readouterr().err
+
+
+class TestListCachedVersions:
+    """list_cached_versions() orders versions numerically, newest first."""
+
+    def test_orders_versions_numerically(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sdk_loader, "CACHE_DIR", tmp_path)
+        for version in ("v0.2.9", "v0.2.16", "v0.10.0"):
+            (tmp_path / f"genvm-universal-{version}.tar.xz").write_bytes(b"")
+
+        assert sdk_loader.list_cached_versions() == ["v0.10.0", "v0.2.16", "v0.2.9"]
+
+
+class TestDownloadArtifacts:
+    """download_artifacts() resolves whichever bundle asset a release ships."""
+
+    @staticmethod
+    def _http_404(url):
+        return urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    def test_returns_cached_tarball_without_downloading(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sdk_loader, "CACHE_DIR", tmp_path)
+        cached = tmp_path / "genvm-universal-v0.2.16.tar.xz"
+        cached.write_bytes(b"cached")
+
+        def _fail(*a, **k):
+            raise AssertionError("should not download a cached tarball")
+
+        monkeypatch.setattr(sdk_loader, "_download_to", _fail)
+
+        assert sdk_loader.download_artifacts("v0.2.16") == cached
+
+    def test_uses_first_available_asset(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sdk_loader, "CACHE_DIR", tmp_path)
+        tried = []
+
+        def _download(url, dest):
+            tried.append(url)
+            dest.write_bytes(b"bundle")
+
+        monkeypatch.setattr(sdk_loader, "_download_to", _download)
+
+        result = sdk_loader.download_artifacts("v0.3.0")
+
+        assert result == tmp_path / "genvm-universal-v0.3.0.tar.xz"
+        assert result.read_bytes() == b"bundle"
+        assert tried == [
+            f"{sdk_loader.GITHUB_RELEASES_URL}/download/v0.3.0/genvm-runners-all.tar.xz"
+        ]
+
+    def test_falls_back_to_old_asset_on_404(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sdk_loader, "CACHE_DIR", tmp_path)
+        tried = []
+
+        def _download(url, dest):
+            tried.append(url)
+            if url.endswith("genvm-runners-all.tar.xz"):
+                raise self._http_404(url)
+            dest.write_bytes(b"bundle")
+
+        monkeypatch.setattr(sdk_loader, "_download_to", _download)
+
+        result = sdk_loader.download_artifacts("v0.2.16")
+
+        assert result.read_bytes() == b"bundle"
+        assert [u.rsplit("/", 1)[-1] for u in tried] == list(
+            sdk_loader.RUNNER_BUNDLE_ASSETS
+        )
+
+    def test_raises_when_no_asset_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sdk_loader, "CACHE_DIR", tmp_path)
+
+        def _download(url, dest):
+            raise self._http_404(url)
+
+        monkeypatch.setattr(sdk_loader, "_download_to", _download)
+
+        try:
+            sdk_loader.download_artifacts("v9.9.9")
+        except FileNotFoundError as e:
+            assert "v9.9.9" in str(e)
+        else:
+            raise AssertionError("expected FileNotFoundError")

--- a/uv.lock
+++ b/uv.lock
@@ -688,19 +688,19 @@ wheels = [
 
 [[package]]
 name = "genlayer-py"
-version = "0.9.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/ca/58d286f63ccd56049127dc6e800fb8be3fc01aa96fa13defcc03f2982648/genlayer_py-0.9.0.tar.gz", hash = "sha256:10669d34f080f40873b476651a8e710ef0c1658e012857446c08a939a9e86096", size = 72639, upload-time = "2025-09-09T14:30:00.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/99/8f2d98de18bb1c6533a7b04487d6333564a94fb0b85e972042292cceafda/genlayer_py-0.18.0.tar.gz", hash = "sha256:184954732e16b61f1a8465ff8a8ab8bdcd99952b5285271ad47d523f68136940", size = 45155, upload-time = "2026-04-22T14:27:11.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/c7/18c3dbf1a9c432e5584ee0bd6e8dc2ffbeeda99d1338e925d61da229adca/genlayer_py-0.9.0-py3-none-any.whl", hash = "sha256:e98530d4e3eaa5faf399a5fcb4af3e085921d10e250132ba150ade638cd91939", size = 110748, upload-time = "2025-09-09T14:29:59.634Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f8/a1fdd3e7c5a7c79fce774aacd535fec2bddfc742d0feabbb8770118d8b67/genlayer_py-0.18.0-py3-none-any.whl", hash = "sha256:d18cb57a6ee2c09d8db32659b9f152d4cef50d3c2308da2975bab7ae41b2e5a0", size = 58336, upload-time = "2026-04-22T14:27:12.061Z" },
 ]
 
 [[package]]
 name = "genlayer-test"
-version = "0.20.2"
+version = "0.29.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
@@ -708,7 +708,6 @@ dependencies = [
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "setuptools" },
 ]
 
 [package.optional-dependencies]
@@ -724,12 +723,11 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "eth-account", marker = "extra == 'sim'", specifier = ">=0.10" },
     { name = "fastapi", marker = "extra == 'sim'", specifier = ">=0.100" },
-    { name = "genlayer-py", specifier = "==0.9.0" },
+    { name = "genlayer-py", specifier = ">=0.18.0,<0.19.0" },
     { name = "httpx", marker = "extra == 'sim'", specifier = ">=0.24" },
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "setuptools", specifier = ">=77.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'sim'", specifier = ">=0.20" },
 ]
 provides-extras = ["sim"]
@@ -1374,15 +1372,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/2d/439b0728a92964a04d9c88ea1ca9ebb128893fbbd5834faa31f987f2fd4c/rlp-4.1.0.tar.gz", hash = "sha256:be07564270a96f3e225e2c107db263de96b5bc1f27722d2855bd3459a08e95a9", size = 33429, upload-time = "2025-02-04T22:05:59.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/fb/e4c0ced9893b84ac95b7181d69a9786ce5879aeb3bbbcbba80a164f85d6a/rlp-4.1.0-py3-none-any.whl", hash = "sha256:8eca394c579bad34ee0b937aecb96a57052ff3716e19c7a578883e767bc5da6f", size = 19973, upload-time = "2025-02-04T22:05:57.05Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
- resolve GenVM releases through the GitHub releases API and accept both genvm-runners-all.tar.xz and genvm-universal.tar.xz
- add GENVM_VERSION/cache/latest precedence tests for the direct runner artifact loader
- move genlayer-test to the fee-aware genlayer-py 0.18.x dependency line and refresh uv.lock

Validation:
- env UV_CACHE_DIR=/private/tmp/genlayer-testing-suite-uv-cache uv run pytest tests/gltest_direct/test_sdk_loader.py
- env UV_CACHE_DIR=/private/tmp/genlayer-testing-suite-uv-cache uv run pytest tests/gltest/ tests/gltest_cli/ tests/gltest_direct/test_sdk_loader.py
- env UV_CACHE_DIR=/private/tmp/genlayer-testing-suite-uv-cache uv run gltest tests/gltest_direct/test_sdk_loader.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable support for pinning GenVM versions during SDK downloads.
  * Improved GenVM version resolution to automatically select the latest stable release from GitHub with proper runner bundle assets.

* **Chores**
  * Updated project dependencies to require newer versions.
  * Added console script entry point for CLI tool.
  * Expanded test coverage for SDK loader functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-testing-suite/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->