### PR TITLE
fix: support GenVM v0.3 direct SDK layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ GenLayer contracts are Python classes:
 ```python
 import genlayer as gl
 
-class MyContract(gl.Contract):
+class MyContract(gl.contract.Contract):
     def __init__(self, initial_value: int):
         self.value = initial_value
     

--- a/README.md
+++ b/README.md
@@ -367,9 +367,9 @@ print(f"Unique states: {analysis.unique_states}")
 ## Example Contract
 
 ```python
-from genlayer import *
+import genlayer as gl
 
-class Storage(gl.Contract):
+class Storage(gl.contract.Contract):
     storage: str
 
     def __init__(self, initial_storage: str):
@@ -400,7 +400,7 @@ For more examples, see the [contracts directory](tests/examples/contracts).
 
 ## Troubleshooting
 
-**Contract not found**: Ensure contracts are in `contracts/` or specify `--contracts-dir`. Contracts must inherit from `gl.Contract`.
+**Contract not found**: Ensure contracts are in `contracts/` or specify `--contracts-dir`. Contracts must inherit from `gl.contract.Contract`.
 
 **Transaction timeouts** (Studio mode): Increase `wait_interval` and `wait_retries` in `.transact()`.
 

--- a/docs/api-references/index.md
+++ b/docs/api-references/index.md
@@ -362,9 +362,9 @@ print(f"Unique states: {analysis.unique_states}")
 ## Example Contract
 
 ```python
-from genlayer import *
+import genlayer as gl
 
-class Storage(gl.Contract):
+class Storage(gl.contract.Contract):
     storage: str
 
     def __init__(self, initial_storage: str):
@@ -395,7 +395,7 @@ For more examples, see the [contracts directory](tests/examples/contracts).
 
 ## Troubleshooting
 
-**Contract not found**: Ensure contracts are in `contracts/` or specify `--contracts-dir`. Contracts must inherit from `gl.Contract`.
+**Contract not found**: Ensure contracts are in `contracts/` or specify `--contracts-dir`. Contracts must inherit from `gl.contract.Contract`.
 
 **Transaction timeouts** (Studio mode): Increase `wait_interval` and `wait_retries` in `.transact()`.
 

--- a/docs/direct-runner.md
+++ b/docs/direct-runner.md
@@ -359,9 +359,9 @@ Direct mode automatically downloads and caches the correct GenLayer SDK version 
 # Contract with version header
 # { "Depends": "py-genlayer:abc123..." }
 
-from genlayer import *
+import genlayer as gl
 
-class MyContract(gl.Contract):
+class MyContract(gl.contract.Contract):
     ...
 ```
 

--- a/docs/studio-runner.md
+++ b/docs/studio-runner.md
@@ -972,16 +972,16 @@ gltest --contracts-dir /path/to/contracts
 
 ### Contract Structure Issues
 
-Contracts must inherit from `gl.Contract`:
+Contracts must inherit from `gl.contract.Contract`:
 
 ```python
 # Correct
-from genlayer import *
+import genlayer as gl
 
-class MyContract(gl.Contract):
+class MyContract(gl.contract.Contract):
     pass
 
-# Wrong — missing gl.Contract inheritance
+# Wrong — missing gl.contract.Contract inheritance
 class MyContract:
     pass
 ```

--- a/glsim/README.md
+++ b/glsim/README.md
@@ -144,7 +144,7 @@ Contracts that read sibling files via `open("/contract/OtherModule.py")` work �
 
 ### Cross-Contract Calls
 
-Contracts using `gl.deploy_contract()`, `gl.contract_at().view()`, and `gl.contract_at().emit()` work. glsim handles:
+Contracts using `gl.contract.deploy()`, `gl.contract.get_at().view()`, and `gl.contract.get_at().emit()` work. glsim handles:
 - **DeployContract** — deploys child contract with isolated storage
 - **CallContract** — calls method on deployed contract, returns result
 - **PostMessage** — fire-and-forget call (no return value)

--- a/glsim/consensus.py
+++ b/glsim/consensus.py
@@ -101,7 +101,7 @@ def run_consensus(
 
 def _run_validators(vm, captured, num_validators):
     """Run captured validator_fns for each validator. Returns list of votes."""
-    import genlayer.gl.vm as gl_vm
+    import genlayer.vm as gl_vm
 
     votes = []
     for _ in range(num_validators):

--- a/glsim/engine.py
+++ b/glsim/engine.py
@@ -194,7 +194,7 @@ class SimEngine:
         self._storages[addr_key] = storage
         self.vm._storage = storage
 
-        # Set gl.message so __init__ can read contract_address if needed
+        # Set genlayer.message so __init__ can read contract_address if needed
         self._set_message_context(
             contract_address=addr_bytes,
             sender=self.vm.sender,
@@ -210,9 +210,9 @@ class SimEngine:
             instance = deploy_contract(path, self.vm, *args, sdk_version=None, **kwargs)
 
         # deploy_contract() may clobber vm._contract_address with sha256(path) —
-        # restore the real address and sync gl.message.
+        # restore the real address and sync genlayer.message.
         self.vm._contract_address = addr_bytes
-        self._sync_gl_message_contract_address(addr_bytes)
+        self._sync_message_contract_address(addr_bytes)
 
         self._instances[addr_key] = instance
 
@@ -270,12 +270,12 @@ class SimEngine:
         if storage is not None:
             self.vm._storage = storage
 
-        # Update gl.message so contract code can read contract_address/sender
+        # Update genlayer.message so contract code can read contract_address/sender
         self._set_message_context(
             contract_address=addr_bytes,
             sender=self.vm.sender,
         )
-        self._sync_gl_message_contract_address(addr_bytes)
+        self._sync_message_contract_address(addr_bytes)
 
         method = getattr(instance, method_name, None)
         if method is None:
@@ -593,16 +593,13 @@ class SimEngine:
     def _reset_contract_registry() -> None:
         """Reset the genlayer SDK's global contract class registry.
 
-        The SDK only allows one Contract subclass. Different SDK versions
-        use different variable names (``__known_contact__`` vs
-        ``__known_contract__``). We clear whichever exists.
+        The SDK only allows one Contract subclass per loaded module.
         """
-        mod = sys.modules.get("genlayer.gl.genvm_contracts")
+        mod = sys.modules.get("genlayer.contract")
         if mod is None:
             return
-        for attr in ("__known_contact__", "__known_contract__"):
-            if hasattr(mod, attr):
-                setattr(mod, attr, None)
+        if hasattr(mod, "__known_contract__"):
+            setattr(mod, "__known_contract__", None)
 
     def _install_live_handlers(self) -> None:
         """Install live web/LLM handlers on the VM context."""
@@ -627,13 +624,10 @@ class SimEngine:
         self.vm._gl_call_hook = hook
 
     def _handle_deploy_in_contract(self, vm: Any, data: Dict) -> bytes:
-        """Handle gl.deploy_contract() from within a running contract."""
+        """Handle gl.contract.deploy() from within a running contract."""
         calldata = import_calldata()
         Address = import_address()
-        try:
-            from genlayer.py._internal import create2_address
-        except ImportError:
-            from genlayer._internal import create2_address
+        from genlayer._internal import create2_address
         self._ensure_direct_mode_runtime_patches()
 
         code = data.get('code', b'')
@@ -676,14 +670,14 @@ class SimEngine:
         vm._storage = child_storage
         vm._contract_address = child_addr_bytes
 
-        # Swap gl.message to child context (like _handle_call_in_contract does)
+        # Swap genlayer.message to child context (like _handle_call_in_contract does)
         # so that child's __init__ sees the correct contract_address & sender.
         saved_message = self._swap_message_context(
             vm,
             sender=parent_contract_address,
             contract_address=child_addr_bytes,
         )
-        self._sync_gl_message_contract_address(child_addr_bytes)
+        self._sync_message_contract_address(child_addr_bytes)
 
         try:
             # Deploy child contract.
@@ -735,7 +729,7 @@ class SimEngine:
         return calldata.encode(Address(child_addr_bytes))
 
     def _handle_call_in_contract(self, vm: Any, data: Dict) -> bytes:
-        """Handle gl.contract_at().view().method() from within a running contract."""
+        """Handle gl.contract.get_at().view().method() from within a running contract."""
         calldata = import_calldata()
         Address = import_address()
         self._ensure_direct_mode_runtime_patches()
@@ -771,7 +765,7 @@ class SimEngine:
             vm._storage = target_storage
         vm._contract_address = bytes.fromhex(addr_key[2:])
 
-        # Swap gl.message context
+        # Swap genlayer.message context
         saved_message = self._swap_message_context(
             vm,
             sender=parent_contract_address,
@@ -794,7 +788,7 @@ class SimEngine:
             self._restore_message_context(saved_message)
 
     def _handle_post_in_contract(self, vm: Any, data: Dict) -> Dict:
-        """Handle gl.contract_at().emit().method() — enqueue for after current call."""
+        """Handle gl.contract.get_at().emit().method() — enqueue for after current call."""
         Address = import_address()
 
         address = data.get('address')
@@ -830,11 +824,11 @@ class SimEngine:
 
     @staticmethod
     def _swap_message_context(vm: Any, sender: Any, contract_address: Any) -> Optional[Dict]:
-        """Swap gl.message for cross-contract calls. Returns saved state."""
-        if 'genlayer.gl' not in sys.modules:
+        """Swap genlayer.message for cross-contract calls. Returns saved state."""
+        message = sys.modules.get('genlayer.message')
+        if message is None:
             return None
         try:
-            gl = sys.modules['genlayer.gl']
             Address = import_address()
 
             if isinstance(sender, bytes):
@@ -842,31 +836,32 @@ class SimEngine:
             if isinstance(contract_address, bytes):
                 contract_address = Address(contract_address)
 
-            saved = {}
-            if hasattr(gl, 'message') and gl.message is not None:
-                saved['message'] = gl.message
-                gl.message = gl.MessageType(
-                    contract_address=contract_address,
-                    sender_address=sender,
-                    origin_address=gl.message.origin_address,
-                    value=gl.message.value,
-                    chain_id=gl.message.chain_id,
-                )
-                sync_message_context(
-                    contract_address=contract_address,
-                    sender_address=sender,
-                )
+            fields = (
+                "contract_address",
+                "sender_address",
+                "origin_address",
+                "value",
+                "chain_id",
+            )
+            saved = {
+                field: getattr(message, field)
+                for field in fields
+                if hasattr(message, field)
+            }
+            sync_message_context(
+                contract_address=contract_address,
+                sender_address=sender,
+            )
             return saved
-        except (ImportError, AttributeError):
+        except ImportError:
             return None
 
     @staticmethod
     def _set_message_context(contract_address: Any, sender: Any) -> None:
-        """Set gl.message for top-level calls (call_method / deploy)."""
-        if 'genlayer.gl' not in sys.modules:
+        """Set genlayer.message for top-level calls (call_method / deploy)."""
+        if 'genlayer.message' not in sys.modules:
             return
         try:
-            gl = sys.modules['genlayer.gl']
             Address = import_address()
 
             if isinstance(contract_address, bytes):
@@ -874,38 +869,21 @@ class SimEngine:
             if isinstance(sender, bytes):
                 sender = Address(sender)
 
-            if hasattr(gl, 'message') and gl.message is not None:
-                gl.message = gl.MessageType(
-                    contract_address=contract_address,
-                    sender_address=sender,
-                    origin_address=gl.message.origin_address,
-                    value=gl.message.value,
-                    chain_id=gl.message.chain_id,
-                )
-                sync_message_context(
-                    contract_address=contract_address,
-                    sender_address=sender,
-                )
-        except (ImportError, AttributeError):
+            sync_message_context(
+                contract_address=contract_address,
+                sender_address=sender,
+            )
+        except ImportError:
             pass
 
     @staticmethod
     def _restore_message_context(saved: Optional[Dict]) -> None:
-        """Restore gl.message after cross-contract call."""
+        """Restore genlayer.message after cross-contract call."""
         if saved is None:
             return
-        gl = sys.modules.get('genlayer.gl')
-        if gl is None:
+        if sys.modules.get('genlayer.message') is None:
             return
-        if 'message' in saved:
-            gl.message = saved['message']
-            sync_message_context(
-                contract_address=gl.message.contract_address,
-                sender_address=gl.message.sender_address,
-                origin_address=gl.message.origin_address,
-                value=gl.message.value,
-                chain_id=gl.message.chain_id,
-            )
+        sync_message_context(**saved)
 
     @staticmethod
     def _install_cloudpickle_bypass() -> None:
@@ -939,26 +917,15 @@ class SimEngine:
         cloudpickle.dumps = _bypass_dumps
 
     @staticmethod
-    def _sync_gl_message_contract_address(addr_bytes: bytes) -> None:
-        """Update gl.message.contract_address to match vm._contract_address."""
-        if 'genlayer.gl' not in sys.modules:
+    def _sync_message_contract_address(addr_bytes: bytes) -> None:
+        """Update genlayer.message.contract_address to match vm._contract_address."""
+        if 'genlayer.message' not in sys.modules:
             return
         try:
-            gl = sys.modules['genlayer.gl']
             Address = import_address()
             new_addr = Address(addr_bytes)
-            if hasattr(gl, 'message') and gl.message is not None:
-                gl.message = gl.MessageType(
-                    contract_address=new_addr,
-                    sender_address=gl.message.sender_address,
-                    origin_address=gl.message.origin_address,
-                    value=gl.message.value,
-                    chain_id=gl.message.chain_id,
-                )
-            if hasattr(gl, 'message_raw') and gl.message_raw is not None:
-                gl.message_raw['contract_address'] = new_addr
             sync_message_context(contract_address=new_addr)
-        except (ImportError, AttributeError):
+        except ImportError:
             pass
 
     @staticmethod

--- a/glsim/engine.py
+++ b/glsim/engine.py
@@ -28,6 +28,7 @@ from gltest.direct.loader import (
     _allocate_contract,
     _patch_run_nondet_for_direct_mode,
 )
+from gltest.direct.sdk_compat import import_address, import_calldata, sync_message_context
 
 from .state import StateStore
 from .tx_decoder import decode_calldata_bytes, encode_calldata_result
@@ -627,9 +628,12 @@ class SimEngine:
 
     def _handle_deploy_in_contract(self, vm: Any, data: Dict) -> bytes:
         """Handle gl.deploy_contract() from within a running contract."""
-        from genlayer.py import calldata
-        from genlayer.py.types import Address
-        from genlayer.py._internal import create2_address
+        calldata = import_calldata()
+        Address = import_address()
+        try:
+            from genlayer.py._internal import create2_address
+        except ImportError:
+            from genlayer._internal import create2_address
         self._ensure_direct_mode_runtime_patches()
 
         code = data.get('code', b'')
@@ -732,8 +736,8 @@ class SimEngine:
 
     def _handle_call_in_contract(self, vm: Any, data: Dict) -> bytes:
         """Handle gl.contract_at().view().method() from within a running contract."""
-        from genlayer.py import calldata
-        from genlayer.py.types import Address
+        calldata = import_calldata()
+        Address = import_address()
         self._ensure_direct_mode_runtime_patches()
 
         address = data.get('address')
@@ -791,7 +795,7 @@ class SimEngine:
 
     def _handle_post_in_contract(self, vm: Any, data: Dict) -> Dict:
         """Handle gl.contract_at().emit().method() — enqueue for after current call."""
-        from genlayer.py.types import Address
+        Address = import_address()
 
         address = data.get('address')
         calldata_obj = data.get('calldata', {})
@@ -831,7 +835,7 @@ class SimEngine:
             return None
         try:
             gl = sys.modules['genlayer.gl']
-            from genlayer.py.types import Address
+            Address = import_address()
 
             if isinstance(sender, bytes):
                 sender = Address(sender)
@@ -848,6 +852,10 @@ class SimEngine:
                     value=gl.message.value,
                     chain_id=gl.message.chain_id,
                 )
+                sync_message_context(
+                    contract_address=contract_address,
+                    sender_address=sender,
+                )
             return saved
         except (ImportError, AttributeError):
             return None
@@ -859,7 +867,7 @@ class SimEngine:
             return
         try:
             gl = sys.modules['genlayer.gl']
-            from genlayer.py.types import Address
+            Address = import_address()
 
             if isinstance(contract_address, bytes):
                 contract_address = Address(contract_address)
@@ -874,6 +882,10 @@ class SimEngine:
                     value=gl.message.value,
                     chain_id=gl.message.chain_id,
                 )
+                sync_message_context(
+                    contract_address=contract_address,
+                    sender_address=sender,
+                )
         except (ImportError, AttributeError):
             pass
 
@@ -887,6 +899,13 @@ class SimEngine:
             return
         if 'message' in saved:
             gl.message = saved['message']
+            sync_message_context(
+                contract_address=gl.message.contract_address,
+                sender_address=gl.message.sender_address,
+                origin_address=gl.message.origin_address,
+                value=gl.message.value,
+                chain_id=gl.message.chain_id,
+            )
 
     @staticmethod
     def _install_cloudpickle_bypass() -> None:
@@ -926,7 +945,7 @@ class SimEngine:
             return
         try:
             gl = sys.modules['genlayer.gl']
-            from genlayer.py.types import Address
+            Address = import_address()
             new_addr = Address(addr_bytes)
             if hasattr(gl, 'message') and gl.message is not None:
                 gl.message = gl.MessageType(
@@ -938,6 +957,7 @@ class SimEngine:
                 )
             if hasattr(gl, 'message_raw') and gl.message_raw is not None:
                 gl.message_raw['contract_address'] = new_addr
+            sync_message_context(contract_address=new_addr)
         except (ImportError, AttributeError):
             pass
 

--- a/gltest/artifacts/contract.py
+++ b/gltest/artifacts/contract.py
@@ -37,16 +37,11 @@ def search_path_by_class_name(contracts_dir: Path, contract_name: str) -> Path:
             # Search for class definitions
             for node in ast.walk(tree):
                 if isinstance(node, ast.ClassDef) and node.name == contract_name:
-                    # Check if the class directly inherits from gl.Contract
+                    # Check if the class directly inherits from gl.contract.Contract
                     for base in node.bases:
-                        if isinstance(base, ast.Attribute):
-                            if (
-                                isinstance(base.value, ast.Name)
-                                and base.value.id == "gl"
-                                and base.attr == "Contract"
-                            ):
-                                matching_files.append(file_path)
-                                break
+                        if _is_genlayer_contract_base(base):
+                            matching_files.append(file_path)
+                            break
                     break
         except Exception as e:
             raise ValueError(f"Error reading file {file_path}: {e}") from e
@@ -97,21 +92,28 @@ def _extract_contract_name_from_file(file_path: Path) -> str:
             content = f.read()
         tree = ast.parse(content)
 
-        # Search for class definitions that inherit from gl.Contract
+        # Search for class definitions that inherit from gl.contract.Contract
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 for base in node.bases:
-                    if (
-                        isinstance(base, ast.Attribute)
-                        and isinstance(base.value, ast.Name)
-                        and base.value.id == "gl"
-                        and base.attr == "Contract"
-                    ):
+                    if _is_genlayer_contract_base(base):
                         return node.name
     except Exception as e:
         raise ValueError(f"Error parsing contract file {file_path}: {e}") from e
 
     raise ValueError(f"No valid contract class found in {file_path}")
+
+
+def _is_genlayer_contract_base(base: ast.expr) -> bool:
+    """Return True for ``gl.contract.Contract`` inheritance."""
+    return (
+        isinstance(base, ast.Attribute)
+        and base.attr == "Contract"
+        and isinstance(base.value, ast.Attribute)
+        and base.value.attr == "contract"
+        and isinstance(base.value.value, ast.Name)
+        and base.value.value.id == "gl"
+    )
 
 
 def _create_contract_definition(

--- a/gltest/direct/loader.py
+++ b/gltest/direct/loader.py
@@ -25,7 +25,6 @@ from .sdk_compat import (
     import_address,
     import_calldata,
     import_lazy,
-    install_star_import_compat,
 )
 
 
@@ -57,13 +56,10 @@ def load_contract_class(
     #    (genlayer reads message from fd 0 at import time)
     _inject_message_to_fd0(vm)
 
-    # 4. Keep older star-import contracts usable with current GenVM SDKs.
-    install_star_import_compat()
-
-    # 5. Patch get_type_hints for PEP 695 compat (Python 3.12.0-3.12.7)
+    # 4. Patch get_type_hints for PEP 695 compat (Python 3.12.0-3.12.7)
     _patch_get_type_hints_for_pep695()
 
-    # 6. Load the contract module
+    # 5. Load the contract module
     module = _load_module(contract_path)
 
     contract_cls = _find_contract_class(module)
@@ -134,7 +130,7 @@ def _patch_get_type_hints_for_pep695() -> None:
 
 
 def _patch_run_nondet_for_direct_mode() -> None:
-    """Replace gl.vm.run_nondet with a direct-mode version.
+    """Replace genlayer.vm.run_nondet with direct-mode versions.
 
     The SDK's run_nondet pickles leader_fn via cloudpickle to pass through
     the WASM boundary. In direct mode there's no WASM, and the closure
@@ -142,7 +138,7 @@ def _patch_run_nondet_for_direct_mode() -> None:
     We bypass pickling by calling leader_fn() directly.
     """
     try:
-        import genlayer.gl.vm as gl_vm
+        import genlayer.vm as gl_vm
     except ImportError:
         return
 
@@ -163,9 +159,12 @@ def _patch_run_nondet_for_direct_mode() -> None:
         vm._captured_validators.append((result, leader_fn, validator_fn))
         return result
 
-    def _direct_run_nondet_unsafe(leader_fn, validator_fn, /):
+    def _direct_run_nondet_default(leader_fn, validator_fn, /, **kwargs):
         from . import wasi_mock
         vm = wasi_mock.get_vm()
+        if vm._check_pickling:
+            _validate_pickling(leader_fn, "leader_fn")
+            _validate_pickling(validator_fn, "validator_fn")
         vm._in_nondet = True
         try:
             result = leader_fn()
@@ -174,7 +173,6 @@ def _patch_run_nondet_for_direct_mode() -> None:
         vm._captured_validators.append((result, leader_fn, validator_fn))
         return result
 
-    # lazy-api compat: eq_principle.strict_eq calls vm.run_nondet_unsafe.lazy()
     # The SDK uses @_lazy_api which attaches .lazy to the eager function.
     # .lazy must return a Lazy[T] wrapper instead of the raw value.
     Lazy = import_lazy()
@@ -182,16 +180,17 @@ def _patch_run_nondet_for_direct_mode() -> None:
     def _lazy_run_nondet(leader_fn, validator_fn, /, **kwargs):
         return Lazy(lambda: _direct_run_nondet(leader_fn, validator_fn, **kwargs))
 
-    def _lazy_run_nondet_unsafe(leader_fn, validator_fn, /):
-        return Lazy(lambda: _direct_run_nondet_unsafe(leader_fn, validator_fn))
+    def _lazy_run_nondet_default(leader_fn, validator_fn, /, **kwargs):
+        return Lazy(
+            lambda: _direct_run_nondet_default(leader_fn, validator_fn, **kwargs)
+        )
 
     _direct_run_nondet.lazy = _lazy_run_nondet
-    _direct_run_nondet_unsafe.lazy = _lazy_run_nondet_unsafe
+    _direct_run_nondet_default.lazy = _lazy_run_nondet_default
 
     gl_vm.run_nondet = _direct_run_nondet
-    gl_vm.run_nondet_unsafe = _direct_run_nondet_unsafe
+    gl_vm.run_nondet_default = _direct_run_nondet_default
     gl_vm._direct_mode_patched = True
-    gl_vm._direct_mode_unsafe_patched = True
 
     # Also mock embeddings (ONNX model not available in direct mode)
     _mock_embeddings_for_direct_mode()
@@ -352,7 +351,7 @@ def _find_contract_class(module: Any) -> Optional[Type[Any]]:
 
         # Second priority: inherits from Contract
         for base in obj.__mro__:
-            if base.__name__ in ('Contract', 'gl.Contract'):
+            if base.__name__ == 'Contract':
                 return obj
 
         # Third priority: has storage-like annotations
@@ -471,25 +470,14 @@ def _allocate_contract(
 ) -> Any:
     """Allocate and initialize a contract instance."""
     try:
-        try:
-            from genlayer.py.storage import Root, ROOT_SLOT_ID
-            from genlayer.py.storage._internal.generate import (
-                ORIGINAL_INIT_ATTR,
-                _storage_build,
-                Lit,
-            )
+        from genlayer.storage import ROOT_SLOT_ID
+        from genlayer.storage._internal.generate import (
+            ORIGINAL_INIT_ATTR,
+            _BuilderCtx,
+            _storage_build,
+        )
 
-            td = _storage_build(contract_cls, {})
-            assert not isinstance(td, Lit)
-        except ImportError:
-            from genlayer.storage import Root, ROOT_SLOT_ID
-            from genlayer.storage._internal.generate import (
-                ORIGINAL_INIT_ATTR,
-                _BuilderCtx,
-                _storage_build,
-            )
-
-            td = _storage_build(_BuilderCtx.empty(), contract_cls)
+        td = _storage_build(_BuilderCtx.empty(), contract_cls)
 
         # Use the VM's storage manager
         slot = vm._storage.get_store_slot(ROOT_SLOT_ID)
@@ -512,10 +500,7 @@ def _allocate_contract(
         pass
 
     try:
-        try:
-            from genlayer.py.storage import Root
-        except ImportError:
-            from genlayer.storage import Root
+        from genlayer.storage import Root
 
         Root.MANAGER = vm._storage
 

--- a/gltest/direct/loader.py
+++ b/gltest/direct/loader.py
@@ -21,6 +21,13 @@ from typing import Any, Optional, Type, TYPE_CHECKING
 if TYPE_CHECKING:
     from .vm import VMContext
 
+from .sdk_compat import (
+    import_address,
+    import_calldata,
+    import_lazy,
+    install_star_import_compat,
+)
+
 
 def load_contract_class(
     contract_path: Path,
@@ -50,10 +57,13 @@ def load_contract_class(
     #    (genlayer reads message from fd 0 at import time)
     _inject_message_to_fd0(vm)
 
-    # 4. Patch get_type_hints for PEP 695 compat (Python 3.12.0-3.12.7)
+    # 4. Keep older star-import contracts usable with current GenVM SDKs.
+    install_star_import_compat()
+
+    # 5. Patch get_type_hints for PEP 695 compat (Python 3.12.0-3.12.7)
     _patch_get_type_hints_for_pep695()
 
-    # 5. Load the contract module
+    # 6. Load the contract module
     module = _load_module(contract_path)
 
     contract_cls = _find_contract_class(module)
@@ -167,7 +177,7 @@ def _patch_run_nondet_for_direct_mode() -> None:
     # lazy-api compat: eq_principle.strict_eq calls vm.run_nondet_unsafe.lazy()
     # The SDK uses @_lazy_api which attaches .lazy to the eager function.
     # .lazy must return a Lazy[T] wrapper instead of the raw value.
-    from genlayer.py.types import Lazy
+    Lazy = import_lazy()
 
     def _lazy_run_nondet(leader_fn, validator_fn, /, **kwargs):
         return Lazy(lambda: _direct_run_nondet(leader_fn, validator_fn, **kwargs))
@@ -240,8 +250,8 @@ def _inject_message_to_fd0(vm: "VMContext") -> None:
     import tempfile
 
     try:
-        from genlayer.py import calldata
-        from genlayer.py.types import Address
+        calldata = import_calldata()
+        Address = import_address()
     except ImportError:
         return
 
@@ -375,7 +385,7 @@ def _calldata_roundtrip_args(
     at deploy time.
     """
     try:
-        from genlayer.py import calldata
+        calldata = import_calldata()
     except ImportError:
         return args, kwargs
 
@@ -461,16 +471,25 @@ def _allocate_contract(
 ) -> Any:
     """Allocate and initialize a contract instance."""
     try:
-        from genlayer.py.storage import Root, ROOT_SLOT_ID
-        from genlayer.py.storage._internal.generate import (
-            ORIGINAL_INIT_ATTR,
-            _storage_build,
-            Lit,
-        )
+        try:
+            from genlayer.py.storage import Root, ROOT_SLOT_ID
+            from genlayer.py.storage._internal.generate import (
+                ORIGINAL_INIT_ATTR,
+                _storage_build,
+                Lit,
+            )
 
-        # Build the storage type descriptor
-        td = _storage_build(contract_cls, {})
-        assert not isinstance(td, Lit)
+            td = _storage_build(contract_cls, {})
+            assert not isinstance(td, Lit)
+        except ImportError:
+            from genlayer.storage import Root, ROOT_SLOT_ID
+            from genlayer.storage._internal.generate import (
+                ORIGINAL_INIT_ATTR,
+                _BuilderCtx,
+                _storage_build,
+            )
+
+            td = _storage_build(_BuilderCtx.empty(), contract_cls)
 
         # Use the VM's storage manager
         slot = vm._storage.get_store_slot(ROOT_SLOT_ID)
@@ -493,7 +512,10 @@ def _allocate_contract(
         pass
 
     try:
-        from genlayer.py.storage import Root
+        try:
+            from genlayer.py.storage import Root
+        except ImportError:
+            from genlayer.storage import Root
 
         Root.MANAGER = vm._storage
 
@@ -520,7 +542,7 @@ def create_address(seed: str) -> Any:
     addr_bytes = hashlib.sha256(seed.encode()).digest()[:20]
 
     try:
-        from genlayer.py.types import Address
+        Address = import_address()
         return Address(addr_bytes)
     except ImportError:
         return addr_bytes

--- a/gltest/direct/sdk_compat.py
+++ b/gltest/direct/sdk_compat.py
@@ -1,38 +1,24 @@
-"""Compatibility helpers for GenVM SDK layout changes."""
+"""Helpers for the GenVM v0.3 SDK layout."""
 
 from __future__ import annotations
 
 import sys
-import types
-import typing
 from typing import Any
 
 _UNSET = object()
 
 
-class MessageType(typing.NamedTuple):
-    contract_address: Any
-    sender_address: Any
-    origin_address: Any
-    value: Any
-    chain_id: Any
-
-
 def import_calldata() -> Any:
-    """Return calldata module from either the v0.2 or v0.3 SDK layout."""
-    try:
-        from genlayer.py import calldata
-    except ImportError:
-        from genlayer import calldata
+    """Return the v0.3 calldata module from the active SDK path."""
+    from genlayer import calldata
+
     return calldata
 
 
 def import_types() -> Any:
-    """Return types module from either the v0.2 or v0.3 SDK layout."""
-    try:
-        from genlayer.py import types as sdk_types
-    except ImportError:
-        from genlayer import types as sdk_types
+    """Return the v0.3 types module from the active SDK path."""
+    from genlayer import types as sdk_types
+
     return sdk_types
 
 
@@ -47,71 +33,6 @@ def import_address_u256() -> tuple[type, Any]:
 
 def import_lazy() -> Any:
     return import_types().Lazy
-
-
-def install_star_import_compat() -> None:
-    """Expose old `from genlayer import *` / `gl.*` surface on v0.3 SDKs."""
-    import genlayer
-
-    if hasattr(genlayer, "gl") and "genlayer.gl" in sys.modules:
-        return
-
-    gl_module = types.ModuleType("genlayer.gl")
-    gl_module.__package__ = "genlayer"
-    gl_module.__path__ = []
-
-    from genlayer import calldata, chain, contract, eq_principle, evm, message
-    from genlayer import nondet, private, public, storage, types as sdk_types, vm
-
-    gl_module.calldata = calldata
-    gl_module.chain = chain
-    gl_module.contract = contract
-    gl_module.eq_principle = eq_principle
-    gl_module.evm = evm
-    gl_module.message = message
-    gl_module.nondet = nondet
-    gl_module.public = public
-    gl_module.private = private
-    gl_module.storage = storage
-    gl_module.vm = vm
-
-    gl_module.Contract = contract.Contract
-    gl_module.MessageType = MessageType
-    gl_module.contract_interface = contract.interface
-    gl_module.deploy_contract = contract.deploy
-    gl_module.get_contract_at = contract.get_at
-    gl_module.get_at = contract.get_at
-    gl_module.message_raw = getattr(message, "raw", None)
-    gl_module.message = MessageType(
-        contract_address=getattr(message, "contract_address", None),
-        sender_address=getattr(message, "sender_address", None),
-        origin_address=getattr(message, "origin_address", None),
-        value=getattr(message, "value", 0),
-        chain_id=getattr(message, "chain_id", 0),
-    )
-
-    sys.modules["genlayer.gl"] = gl_module
-    sys.modules.setdefault("genlayer.gl.vm", vm)
-    sys.modules.setdefault("genlayer.gl.nondet", nondet)
-    sys.modules.setdefault("genlayer.gl.eq_principle", eq_principle)
-    sys.modules.setdefault("genlayer.gl.evm", evm)
-    genlayer.gl = gl_module
-
-    py_module = types.ModuleType("genlayer.py")
-    py_module.__package__ = "genlayer"
-    py_module.__path__ = []
-    py_module.calldata = calldata
-    py_module.evm = evm
-    py_module.types = sdk_types
-    sys.modules["genlayer.py"] = py_module
-    sys.modules.setdefault("genlayer.py.calldata", calldata)
-    sys.modules.setdefault("genlayer.py.evm", evm)
-    sys.modules.setdefault("genlayer.py.types", sdk_types)
-    genlayer.py = py_module
-
-    exported = list(getattr(genlayer, "__all__", ()))
-    if "gl" not in exported:
-        genlayer.__all__ = (*exported, "gl")
 
 
 def _coerce_address(value: Any) -> Any:
@@ -135,7 +56,7 @@ def sync_message_context(
     value: Any = _UNSET,
     chain_id: Any = _UNSET,
 ) -> None:
-    """Synchronize old `genlayer.gl` message fields and v0.3 message module."""
+    """Synchronize the v0.3 message module without triggering a fresh import."""
     contract_address = _coerce_address(contract_address)
     sender_address = _coerce_address(sender_address)
     origin_address = _coerce_address(origin_address)
@@ -157,34 +78,3 @@ def sync_message_context(
             setattr(message_mod, name, next_value)
         if isinstance(raw, dict):
             raw[name] = next_value
-
-    gl = sys.modules.get("genlayer.gl")
-    if gl is None or not hasattr(gl, "MessageType"):
-        return
-
-    current = getattr(gl, "message", None)
-    gl.message = gl.MessageType(
-        contract_address=(
-            contract_address
-            if contract_address is not _UNSET
-            else getattr(current, "contract_address", getattr(message_mod, "contract_address", None))
-        ),
-        sender_address=(
-            sender_address
-            if sender_address is not _UNSET
-            else getattr(current, "sender_address", getattr(message_mod, "sender_address", None))
-        ),
-        origin_address=(
-            origin_address
-            if origin_address is not _UNSET
-            else getattr(current, "origin_address", getattr(message_mod, "origin_address", None))
-        ),
-        value=value if value is not _UNSET else getattr(current, "value", getattr(message_mod, "value", 0)),
-        chain_id=(
-            chain_id
-            if chain_id is not _UNSET
-            else getattr(current, "chain_id", getattr(message_mod, "chain_id", 0))
-        ),
-    )
-    if isinstance(raw, dict):
-        gl.message_raw = raw

--- a/gltest/direct/sdk_compat.py
+++ b/gltest/direct/sdk_compat.py
@@ -1,0 +1,190 @@
+"""Compatibility helpers for GenVM SDK layout changes."""
+
+from __future__ import annotations
+
+import sys
+import types
+import typing
+from typing import Any
+
+_UNSET = object()
+
+
+class MessageType(typing.NamedTuple):
+    contract_address: Any
+    sender_address: Any
+    origin_address: Any
+    value: Any
+    chain_id: Any
+
+
+def import_calldata() -> Any:
+    """Return calldata module from either the v0.2 or v0.3 SDK layout."""
+    try:
+        from genlayer.py import calldata
+    except ImportError:
+        from genlayer import calldata
+    return calldata
+
+
+def import_types() -> Any:
+    """Return types module from either the v0.2 or v0.3 SDK layout."""
+    try:
+        from genlayer.py import types as sdk_types
+    except ImportError:
+        from genlayer import types as sdk_types
+    return sdk_types
+
+
+def import_address() -> type:
+    return import_types().Address
+
+
+def import_address_u256() -> tuple[type, Any]:
+    sdk_types = import_types()
+    return sdk_types.Address, sdk_types.u256
+
+
+def import_lazy() -> Any:
+    return import_types().Lazy
+
+
+def install_star_import_compat() -> None:
+    """Expose old `from genlayer import *` / `gl.*` surface on v0.3 SDKs."""
+    import genlayer
+
+    if hasattr(genlayer, "gl") and "genlayer.gl" in sys.modules:
+        return
+
+    gl_module = types.ModuleType("genlayer.gl")
+    gl_module.__package__ = "genlayer"
+    gl_module.__path__ = []
+
+    from genlayer import calldata, chain, contract, eq_principle, evm, message
+    from genlayer import nondet, private, public, storage, types as sdk_types, vm
+
+    gl_module.calldata = calldata
+    gl_module.chain = chain
+    gl_module.contract = contract
+    gl_module.eq_principle = eq_principle
+    gl_module.evm = evm
+    gl_module.message = message
+    gl_module.nondet = nondet
+    gl_module.public = public
+    gl_module.private = private
+    gl_module.storage = storage
+    gl_module.vm = vm
+
+    gl_module.Contract = contract.Contract
+    gl_module.MessageType = MessageType
+    gl_module.contract_interface = contract.interface
+    gl_module.deploy_contract = contract.deploy
+    gl_module.get_contract_at = contract.get_at
+    gl_module.get_at = contract.get_at
+    gl_module.message_raw = getattr(message, "raw", None)
+    gl_module.message = MessageType(
+        contract_address=getattr(message, "contract_address", None),
+        sender_address=getattr(message, "sender_address", None),
+        origin_address=getattr(message, "origin_address", None),
+        value=getattr(message, "value", 0),
+        chain_id=getattr(message, "chain_id", 0),
+    )
+
+    sys.modules["genlayer.gl"] = gl_module
+    sys.modules.setdefault("genlayer.gl.vm", vm)
+    sys.modules.setdefault("genlayer.gl.nondet", nondet)
+    sys.modules.setdefault("genlayer.gl.eq_principle", eq_principle)
+    sys.modules.setdefault("genlayer.gl.evm", evm)
+    genlayer.gl = gl_module
+
+    py_module = types.ModuleType("genlayer.py")
+    py_module.__package__ = "genlayer"
+    py_module.__path__ = []
+    py_module.calldata = calldata
+    py_module.evm = evm
+    py_module.types = sdk_types
+    sys.modules["genlayer.py"] = py_module
+    sys.modules.setdefault("genlayer.py.calldata", calldata)
+    sys.modules.setdefault("genlayer.py.evm", evm)
+    sys.modules.setdefault("genlayer.py.types", sdk_types)
+    genlayer.py = py_module
+
+    exported = list(getattr(genlayer, "__all__", ()))
+    if "gl" not in exported:
+        genlayer.__all__ = (*exported, "gl")
+
+
+def _coerce_address(value: Any) -> Any:
+    if value is _UNSET or value is None:
+        return value
+    Address = import_address()
+    if isinstance(value, Address):
+        return value
+    if isinstance(value, bytes):
+        return Address(value)
+    if hasattr(value, "as_bytes"):
+        return Address(value.as_bytes)
+    return value
+
+
+def sync_message_context(
+    *,
+    contract_address: Any = _UNSET,
+    sender_address: Any = _UNSET,
+    origin_address: Any = _UNSET,
+    value: Any = _UNSET,
+    chain_id: Any = _UNSET,
+) -> None:
+    """Synchronize old `genlayer.gl` message fields and v0.3 message module."""
+    contract_address = _coerce_address(contract_address)
+    sender_address = _coerce_address(sender_address)
+    origin_address = _coerce_address(origin_address)
+
+    message_mod = sys.modules.get("genlayer.message")
+    raw = getattr(message_mod, "raw", None) if message_mod is not None else None
+
+    updates = {
+        "contract_address": contract_address,
+        "sender_address": sender_address,
+        "origin_address": origin_address,
+        "value": value,
+        "chain_id": chain_id,
+    }
+    for name, next_value in updates.items():
+        if next_value is _UNSET:
+            continue
+        if message_mod is not None:
+            setattr(message_mod, name, next_value)
+        if isinstance(raw, dict):
+            raw[name] = next_value
+
+    gl = sys.modules.get("genlayer.gl")
+    if gl is None or not hasattr(gl, "MessageType"):
+        return
+
+    current = getattr(gl, "message", None)
+    gl.message = gl.MessageType(
+        contract_address=(
+            contract_address
+            if contract_address is not _UNSET
+            else getattr(current, "contract_address", getattr(message_mod, "contract_address", None))
+        ),
+        sender_address=(
+            sender_address
+            if sender_address is not _UNSET
+            else getattr(current, "sender_address", getattr(message_mod, "sender_address", None))
+        ),
+        origin_address=(
+            origin_address
+            if origin_address is not _UNSET
+            else getattr(current, "origin_address", getattr(message_mod, "origin_address", None))
+        ),
+        value=value if value is not _UNSET else getattr(current, "value", getattr(message_mod, "value", 0)),
+        chain_id=(
+            chain_id
+            if chain_id is not _UNSET
+            else getattr(current, "chain_id", getattr(message_mod, "chain_id", 0))
+        ),
+    )
+    if isinstance(raw, dict):
+        gl.message_raw = raw

--- a/gltest/direct/vm.py
+++ b/gltest/direct/vm.py
@@ -52,7 +52,7 @@ class Snapshot:
 
 class InmemManager:
     """
-    In-memory storage manager compatible with genlayer.py.storage.
+    In-memory storage manager compatible with genlayer.storage.
     """
 
     def __init__(self):
@@ -113,7 +113,7 @@ class InmemManager:
 
 
 class Slot:
-    """Storage slot compatible with genlayer.py.storage."""
+    """Storage slot compatible with genlayer.storage."""
 
     __slots__ = ('id', 'manager', '_indir_cache')
 
@@ -372,10 +372,10 @@ class VMContext:
 
         stored_result, leader_fn, validator_fn = self._captured_validators[index]
 
-        import genlayer.gl.vm as gl_vm
+        import genlayer.vm as gl_vm
 
         if leader_error is not None:
-            wrapped = gl_vm.UserError(message=str(leader_error))
+            wrapped = gl_vm.UserError(str(leader_error))
         elif leader_result is not _sentinel:
             wrapped = gl_vm.Return(calldata=leader_result)
         else:
@@ -584,20 +584,19 @@ class VMContext:
 
     def _refresh_gl_message(self) -> None:
         """
-        Refresh gl.message and gl.message_raw to reflect current sender.
+        Refresh genlayer.message to reflect current sender.
 
-        GenLayer SDK caches gl.message at import time. This method updates
-        the cached values so contracts see the current vm.sender.
+        The SDK reads genlayer.message from stdin at import time. This method
+        updates the loaded module so contracts see the current vm.sender.
 
-        Only updates if genlayer.gl is already imported - we must not trigger
-        a fresh import as that would read from stdin before message is injected.
+        Only updates if genlayer.message is already imported - we must not
+        trigger a fresh import as that would read from stdin before message is
+        injected.
         """
-        # Only proceed if genlayer.gl is already loaded
-        if 'genlayer.gl' not in sys.modules:
+        if 'genlayer.message' not in sys.modules:
             return
 
         try:
-            gl = sys.modules['genlayer.gl']
             Address, u256 = import_address_u256()
 
             # Convert sender to Address if needed
@@ -615,21 +614,12 @@ class VMContext:
                 elif hasattr(origin, 'as_bytes'):
                     origin = Address(origin.as_bytes)
 
-            # Update message_raw dict (mutable)
-            if hasattr(gl, 'message_raw') and gl.message_raw is not None:
-                gl.message_raw['sender_address'] = sender
-                gl.message_raw['origin_address'] = origin
-            sync_message_context(sender_address=sender, origin_address=origin)
-
-            # Replace gl.message with new NamedTuple (immutable, must recreate)
-            if hasattr(gl, 'message') and gl.message is not None:
-                gl.message = gl.MessageType(
-                    contract_address=gl.message.contract_address,
-                    sender_address=sender,
-                    origin_address=origin,
-                    value=u256(self._value),
-                    chain_id=u256(self._chain_id),
-                )
+            sync_message_context(
+                sender_address=sender,
+                origin_address=origin,
+                value=u256(self._value),
+                chain_id=u256(self._chain_id),
+            )
         except ImportError:
             # genlayer not loaded yet, nothing to update
             pass

--- a/gltest/direct/vm.py
+++ b/gltest/direct/vm.py
@@ -21,6 +21,7 @@ from typing import Any, Optional, Pattern, List, Tuple, Dict
 from unittest.mock import patch
 
 from ..types import MockedWebResponseData
+from .sdk_compat import import_address_u256, sync_message_context
 
 _sentinel = object()
 
@@ -597,7 +598,7 @@ class VMContext:
 
         try:
             gl = sys.modules['genlayer.gl']
-            from genlayer.py.types import Address, u256
+            Address, u256 = import_address_u256()
 
             # Convert sender to Address if needed
             sender = self.sender
@@ -618,6 +619,7 @@ class VMContext:
             if hasattr(gl, 'message_raw') and gl.message_raw is not None:
                 gl.message_raw['sender_address'] = sender
                 gl.message_raw['origin_address'] = origin
+            sync_message_context(sender_address=sender, origin_address=origin)
 
             # Replace gl.message with new NamedTuple (immutable, must recreate)
             if hasattr(gl, 'message') and gl.message is not None:

--- a/gltest/direct/wasi_mock.py
+++ b/gltest/direct/wasi_mock.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .vm import VMContext
 
+from .sdk_compat import import_calldata
+
 # Thread-local VM context for parallel test safety
 _local = threading.local()
 
@@ -95,7 +97,7 @@ def gl_call(data: bytes, /) -> int:
     fd_buffers = getattr(_local, 'fd_buffers', {})
 
     try:
-        from genlayer.py import calldata
+        calldata = import_calldata()
         request = calldata.decode(data)
     except Exception as e:
         vm._trace(f"gl_call decode error: {e}")
@@ -126,7 +128,7 @@ def gl_call(data: bytes, /) -> int:
         # Regular responses (web, llm, etc) are just calldata-encoded
         # The SDK's _decode_nondet expects plain {"ok": ...} format
         try:
-            from genlayer.py import calldata
+            calldata = import_calldata()
             encoded = calldata.encode(response)
         except Exception as e:
             vm._trace(f"gl_call encode error: {e}")
@@ -340,7 +342,7 @@ def _handle_run_nondet(vm: "VMContext", data: Any) -> Any:
     the leader function, returning its result.
     """
     import cloudpickle
-    from genlayer.py import calldata
+    calldata = import_calldata()
 
     data_leader = data.get("data_leader")
     if not data_leader:

--- a/tests/examples/contracts/football_prediction_market.py
+++ b/tests/examples/contracts/football_prediction_market.py
@@ -1,18 +1,18 @@
 # v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 import json
 import typing
 
 
-class PredictionMarket(gl.Contract):
+class PredictionMarket(gl.contract.Contract):
     has_resolved: bool
     team1: str
     team2: str
     resolution_url: str
-    winner: u256
+    winner: gl.u256
     score: str
 
     def __init__(self, game_date: str, team1: str, team2: str):
@@ -37,7 +37,7 @@ class PredictionMarket(gl.Contract):
         )
         self.team1 = team1
         self.team2 = team2
-        self.winner = u256(0)
+        self.winner = gl.u256(0)
         self.score = ""
 
     @gl.public.write

--- a/tests/examples/contracts/intelligent_oracle.py
+++ b/tests/examples/contracts/intelligent_oracle.py
@@ -1,11 +1,11 @@
 # v0.1.0
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
 import json
 from enum import Enum
 from datetime import datetime, timezone
 from urllib.parse import urlparse
-from genlayer import *
+import genlayer as gl
 
 
 class Status(Enum):
@@ -14,15 +14,15 @@ class Status(Enum):
     ERROR = "Error"
 
 
-class IntelligentOracle(gl.Contract):
+class IntelligentOracle(gl.contract.Contract):
     # Declare persistent storage fields
     prediction_market_id: str
     title: str
     description: str
-    potential_outcomes: DynArray[str]
-    rules: DynArray[str]
-    data_source_domains: DynArray[str]
-    resolution_urls: DynArray[str]
+    potential_outcomes: gl.DynArray[str]
+    rules: gl.DynArray[str]
+    data_source_domains: gl.DynArray[str]
+    resolution_urls: gl.DynArray[str]
     earliest_resolution_date: str  # Store as ISO format string
     status: str  # Store as string since Enum isn't supported
     analysis: str  # Store analysis results

--- a/tests/examples/contracts/intelligent_oracle_factory.py
+++ b/tests/examples/contracts/intelligent_oracle_factory.py
@@ -1,12 +1,12 @@
 # v0.1.0
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class Registry(gl.Contract):
+class Registry(gl.contract.Contract):
     # Declare persistent storage fields
-    contract_addresses: DynArray[str]
+    contract_addresses: gl.DynArray[str]
     intelligent_oracle_code: str
 
     def __init__(self, intelligent_oracle_code: str):
@@ -25,7 +25,7 @@ class Registry(gl.Contract):
         earliest_resolution_date: str,
     ) -> None:
         registered_contracts = len(self.contract_addresses)
-        contract_address = gl.deploy_contract(
+        contract_address = gl.contract.deploy(
             code=self.intelligent_oracle_code.encode("utf-8"),
             args=[
                 prediction_market_id,

--- a/tests/examples/contracts/invalid_deploy.py
+++ b/tests/examples/contracts/invalid_deploy.py
@@ -1,9 +1,9 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
 import genlayer as gl
 
 
-class InvalidDeploy(gl.Contract):
+class InvalidDeploy(gl.contract.Contract):
     """Contract that always fails during deployment"""
 
     def __init__(self):

--- a/tests/examples/contracts/llm_erc20.py
+++ b/tests/examples/contracts/llm_erc20.py
@@ -3,14 +3,14 @@
 
 import json
 
-from genlayer import *
+import genlayer as gl
 
 
-class LlmErc20(gl.Contract):
-    balances: TreeMap[Address, u256]
+class LlmErc20(gl.contract.Contract):
+    balances: gl.TreeMap[gl.Address, gl.u256]
 
     def __init__(self, total_supply: int) -> None:
-        self.balances[gl.message.sender_address] = u256(total_supply)
+        self.balances[gl.message.sender_address] = gl.u256(total_supply)
 
     @gl.public.write
     def transfer(self, amount: int, to_address: str) -> None:
@@ -20,7 +20,7 @@ The current balance for all users in JSON format is:
 {json.dumps(self.get_balances())}
 The transaction to compute is: {{
 sender: "{gl.message.sender_address.as_hex}",
-recipient: "{Address(to_address).as_hex}",
+recipient: "{gl.Address(to_address).as_hex}",
 amount: {amount},
 }}
 
@@ -59,7 +59,7 @@ The total sum of all balances should remain the same before and after the transa
         print("final_result: ", final_result)
         result_json = json.loads(final_result)
         for k, v in result_json["updated_balances"].items():
-            self.balances[Address(k)] = v
+            self.balances[gl.Address(k)] = v
 
     @gl.public.view
     def get_balances(self) -> dict[str, int]:
@@ -67,4 +67,4 @@ The total sum of all balances should remain the same before and after the transa
 
     @gl.public.view
     def get_balance_of(self, address: str) -> int:
-        return self.balances.get(Address(address), 0)
+        return self.balances.get(gl.Address(address), 0)

--- a/tests/examples/contracts/log_indexer.py
+++ b/tests/examples/contracts/log_indexer.py
@@ -1,28 +1,28 @@
 # v0.1.0
 # {
 #   "Seq": [
-#     { "Depends": "py-lib-genlayer-embeddings:09h0i209wrzh4xzq86f79c60x0ifs7xcjwl53ysrnw06i54ddxyi" },
+#     { "Depends": "py-lib-genlayer-embeddings:latest" },
 #     { "Depends": "py-genlayer:latest" }
 #   ]
 # }
 
 import numpy as np
-from genlayer import *
+import genlayer as gl
 import genlayer_embeddings as gle
 
 from dataclasses import dataclass
 import typing
 
 
-@allow_storage
+@gl.storage.allow
 @dataclass
 class StoreValue:
-    log_id: u256
+    log_id: gl.u256
     text: str
 
 
 # contract class
-class LogIndexer(gl.Contract):
+class LogIndexer(gl.contract.Contract):
     vector_store: gle.VecDB[np.float32, typing.Literal[384], StoreValue]
 
     def __init__(self):
@@ -53,14 +53,14 @@ class LogIndexer(gl.Contract):
     @gl.public.write
     def add_log(self, log: str, log_id: int) -> None:
         emb = self.get_embedding(log)
-        self.vector_store.insert(emb, StoreValue(text=log, log_id=u256(log_id)))
+        self.vector_store.insert(emb, StoreValue(text=log, log_id=gl.u256(log_id)))
 
     @gl.public.write
     def update_log(self, log_id: int, log: str) -> None:
         emb = self.get_embedding(log)
         for elem in self.vector_store.knn(emb, 2):
             if elem.value.text == log:
-                elem.value.log_id = u256(log_id)
+                elem.value.log_id = gl.u256(log_id)
 
     @gl.public.write
     def remove_log(self, id: int) -> None:

--- a/tests/examples/contracts/multi_file_contract/__init__.py
+++ b/tests/examples/contracts/multi_file_contract/__init__.py
@@ -1,17 +1,17 @@
-from genlayer import *
+import genlayer as gl
 
 
-class MultiFileContract(gl.Contract):
-    other_addr: Address
+class MultiFileContract(gl.contract.Contract):
+    other_addr: gl.Address
 
     def __init__(self):
         with open("/contract/other.py", "rt") as f:
             text = f.read()
-        self.other_addr = gl.deploy_contract(
+        self.other_addr = gl.contract.deploy(
             code=text.encode("utf-8"),
             args=["123"],
-            salt_nonce=u256(1),
-            value=u256(0),
+            salt_nonce=gl.u256(1),
+            value=gl.u256(0),
             on="accepted",
         )
 
@@ -21,4 +21,4 @@ class MultiFileContract(gl.Contract):
 
     @gl.public.view
     def test(self) -> str:
-        return gl.get_contract_at(self.other_addr).view().test()
+        return gl.contract.get_at(self.other_addr).view().test()

--- a/tests/examples/contracts/multi_file_contract/other.py
+++ b/tests/examples/contracts/multi_file_contract/other.py
@@ -1,9 +1,9 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class Other(gl.Contract):
+class Other(gl.contract.Contract):
     data: str
 
     def __init__(self, data: str):

--- a/tests/examples/contracts/multi_file_contract/runner.json
+++ b/tests/examples/contracts/multi_file_contract/runner.json
@@ -1,3 +1,3 @@
 {
-    "Depends": "py-genlayer-multi:test"
+    "Depends": "py-genlayer-multi:latest"
 }

--- a/tests/examples/contracts/multi_read_erc20.py
+++ b/tests/examples/contracts/multi_read_erc20.py
@@ -1,11 +1,11 @@
 # v0.1.0
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class multi_read_erc20(gl.Contract):
-    balances: TreeMap[Address, TreeMap[Address, u256]]
+class multi_read_erc20(gl.contract.Contract):
+    balances: gl.TreeMap[gl.Address, gl.TreeMap[gl.Address, gl.u256]]
 
     def __init__(self):
         pass
@@ -15,10 +15,10 @@ class multi_read_erc20(gl.Contract):
         self, account_address: str, token_contracts: list[str]
     ) -> None:
         for token_contract in token_contracts:
-            contract = gl.get_contract_at(Address(token_contract))
+            contract = gl.contract.get_at(gl.Address(token_contract))
             balance = contract.view().get_balance_of(account_address)
-            self.balances.get_or_insert_default(Address(account_address))[
-                Address(token_contract)
+            self.balances.get_or_insert_default(gl.Address(account_address))[
+                gl.Address(token_contract)
             ] = balance
 
     @gl.public.view

--- a/tests/examples/contracts/multi_tenant_storage.py
+++ b/tests/examples/contracts/multi_tenant_storage.py
@@ -1,10 +1,10 @@
 # v0.1.0
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class MultiTentantStorage(gl.Contract):
+class MultiTentantStorage(gl.contract.Contract):
     """
     Same functionality as UserStorage, but implemented with multiple storage contracts.
     Each user is assigned to a storage contract, and all storage contracts are managed by this same contract.
@@ -12,16 +12,16 @@ class MultiTentantStorage(gl.Contract):
     This is done to test contract calls between different contracts.
     """
 
-    all_storage_contracts: DynArray[Address]
-    available_storage_contracts: DynArray[Address]
-    mappings: TreeMap[
-        Address, Address
+    all_storage_contracts: gl.DynArray[gl.Address]
+    available_storage_contracts: gl.DynArray[gl.Address]
+    mappings: gl.TreeMap[
+        gl.Address, gl.Address
     ]  # mapping of user address to storage contract address
 
     def __init__(self, storage_contracts: list[str]):
         for el in storage_contracts:
-            self.all_storage_contracts.append(Address(el))
-            self.available_storage_contracts.append(Address(el))
+            self.all_storage_contracts.append(gl.Address(el))
+            self.available_storage_contracts.append(gl.Address(el))
 
     @gl.public.view
     def get_available_contracts(self) -> list[str]:
@@ -30,7 +30,7 @@ class MultiTentantStorage(gl.Contract):
     @gl.public.view
     def get_all_storages(self) -> dict[str, str]:
         return {
-            storage_contract.as_hex: gl.get_contract_at(storage_contract)
+            storage_contract.as_hex: gl.contract.get_at(storage_contract)
             .view()
             .get_storage()
             for storage_contract in self.all_storage_contracts
@@ -46,6 +46,6 @@ class MultiTentantStorage(gl.Contract):
             self.available_storage_contracts.pop()
 
         contract_to_use = self.mappings[gl.message.sender_address]
-        gl.get_contract_at(contract_to_use).emit(on="accepted").update_storage(
+        gl.contract.get_at(contract_to_use).emit(on="accepted").update_storage(
             new_storage
         )

--- a/tests/examples/contracts/read_erc20.py
+++ b/tests/examples/contracts/read_erc20.py
@@ -1,19 +1,19 @@
 # v0.1.0
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class read_erc20(gl.Contract):
-    token_contract: Address
+class read_erc20(gl.contract.Contract):
+    token_contract: gl.Address
 
     def __init__(self, token_contract: str):
-        self.token_contract = Address(token_contract)
+        self.token_contract = gl.Address(token_contract)
 
     @gl.public.view
     def get_balance_of(self, account_address: str) -> int:
         return (
-            gl.get_contract_at(self.token_contract)
+            gl.contract.get_at(self.token_contract)
             .view()
             .get_balance_of(account_address)
         )

--- a/tests/examples/contracts/simple_time_contract.py
+++ b/tests/examples/contracts/simple_time_contract.py
@@ -1,15 +1,14 @@
 # {
 #   "Seq": [
-#     { "Depends": "py-lib-genlayer-embeddings:09h0i209wrzh4xzq86f79c60x0ifs7xcjwl53ysrnw06i54ddxyi" },
-#     { "Depends": "py-genlayer:1j12s63yfjpva9ik2xgnffgrs6v44y1f52jvj9w7xvdn7qckd379" }
+#     { "Depends": "py-genlayer:latest" }
 #   ]
 # }
 
 from datetime import datetime, timezone
-from genlayer import *
+import genlayer as gl
 
 
-class SimpleTimeContract(gl.Contract):
+class SimpleTimeContract(gl.contract.Contract):
     """
     A simple contract that demonstrates time-based function availability.
     """

--- a/tests/examples/contracts/storage.py
+++ b/tests/examples/contracts/storage.py
@@ -1,11 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
 # contract class
-class Storage(gl.Contract):
+class Storage(gl.contract.Contract):
     storage: str
 
     # constructor

--- a/tests/examples/contracts/user_storage.py
+++ b/tests/examples/contracts/user_storage.py
@@ -1,11 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class UserStorage(gl.Contract):
-    storage: TreeMap[Address, str]
+class UserStorage(gl.contract.Contract):
+    storage: gl.TreeMap[gl.Address, str]
 
     # constructor
     def __init__(self):
@@ -18,7 +18,7 @@ class UserStorage(gl.Contract):
 
     @gl.public.view
     def get_account_storage(self, account_address: str) -> str:
-        return self.storage[Address(account_address)]
+        return self.storage[gl.Address(account_address)]
 
     @gl.public.write
     def update_storage(self, new_storage: str) -> None:

--- a/tests/examples/contracts/wizard_of_coin.py
+++ b/tests/examples/contracts/wizard_of_coin.py
@@ -1,11 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:latest" }
-from genlayer import *
+import genlayer as gl
 
 import json
 
 
-class WizardOfCoin(gl.Contract):
+class WizardOfCoin(gl.contract.Contract):
     have_coin: bool
 
     def __init__(self, have_coin: bool):

--- a/tests/examples/contracts/x_username_storage.py
+++ b/tests/examples/contracts/x_username_storage.py
@@ -1,18 +1,17 @@
 # {
 #   "Seq": [
-#     { "Depends": "py-lib-genlayer-embeddings:09h0i209wrzh4xzq86f79c60x0ifs7xcjwl53ysrnw06i54ddxyi" },
-#     { "Depends": "py-genlayer:1j12s63yfjpva9ik2xgnffgrs6v44y1f52jvj9w7xvdn7qckd379" }
+#     { "Depends": "py-genlayer:latest" }
 #   ]
 # }
 
-from genlayer import *
+import genlayer as gl
 
 import json
 import typing
 import urllib.parse
 
 
-class XUsernameStorage(gl.Contract):
+class XUsernameStorage(gl.contract.Contract):
     username: str
     tweet_api_url: str
 

--- a/tests/glsim/deterministic_factory_contract.py
+++ b/tests/glsim/deterministic_factory_contract.py
@@ -1,19 +1,18 @@
-import genlayer.gl as gl
-from genlayer.py.types import u256
+import genlayer as gl
 
 
 CHILD_CODE = """
-import genlayer.gl as gl
+import genlayer as gl
 
 
-class Child(gl.Contract):
+class Child(gl.contract.Contract):
     @gl.public.view
     def ping(self) -> str:
         return "pong"
 """
 
 
-class DeterministicFactory(gl.Contract):
+class DeterministicFactory(gl.contract.Contract):
     child_address: str
 
     def __init__(self):
@@ -21,11 +20,11 @@ class DeterministicFactory(gl.Contract):
 
     @gl.public.write
     def deploy_child(self, salt: int) -> str:
-        child_address = gl.deploy_contract(
+        child_address = gl.contract.deploy(
             code=CHILD_CODE.encode("utf-8"),
             args=[],
             kwargs={},
-            salt_nonce=u256(salt),
+            salt_nonce=gl.u256(salt),
             on="accepted",
         )
         self.child_address = child_address.as_hex

--- a/tests/glsim/disagree_contract.py
+++ b/tests/glsim/disagree_contract.py
@@ -1,11 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 import json
 
 
-class DisagreeContract(gl.Contract):
+class DisagreeContract(gl.contract.Contract):
     result: str
 
     def __init__(self):

--- a/tests/glsim/web_contract.py
+++ b/tests/glsim/web_contract.py
@@ -1,11 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 import json
 
 
-class WebContract(gl.Contract):
+class WebContract(gl.contract.Contract):
     result: str
 
     def __init__(self):

--- a/tests/gltest/artifact/contracts/duplicate_ic_contract_1.py
+++ b/tests/gltest/artifact/contracts/duplicate_ic_contract_1.py
@@ -1,10 +1,10 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
 # contract class
-class DuplicateContract(gl.Contract):
+class DuplicateContract(gl.contract.Contract):
     storage: str
 
     # constructor

--- a/tests/gltest/artifact/contracts/duplicate_ic_contract_2.py
+++ b/tests/gltest/artifact/contracts/duplicate_ic_contract_2.py
@@ -1,10 +1,10 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
 # contract class
-class DuplicateContract(gl.Contract):
+class DuplicateContract(gl.contract.Contract):
     storage: str
 
     # constructor

--- a/tests/gltest/artifact/contracts/not_ic_contract.py
+++ b/tests/gltest/artifact/contracts/not_ic_contract.py
@@ -1,6 +1,6 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:latest" }
 
-from genlayer import *
+import genlayer as gl
 
 
 # contract class that is not an IC contract

--- a/tests/gltest_direct/test_direct_runner.py
+++ b/tests/gltest_direct/test_direct_runner.py
@@ -260,8 +260,8 @@ class TestNondetRestrictions:
         # Deploy contract to get SDK loaded and run_nondet patched
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
-        import genlayer.gl.vm as gl_vm
-        from genlayer.py import calldata
+        import genlayer.vm as gl_vm
+        from genlayer import calldata
         from gltest.direct import wasi_mock
 
         def bad_leader():
@@ -281,8 +281,8 @@ class TestNondetRestrictions:
         """DeployContract inside run_nondet raises RuntimeError."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
-        import genlayer.gl.vm as gl_vm
-        from genlayer.py import calldata
+        import genlayer.vm as gl_vm
+        from genlayer import calldata
         from gltest.direct import wasi_mock
 
         def bad_leader():
@@ -297,8 +297,8 @@ class TestNondetRestrictions:
         """PostMessage inside run_nondet raises RuntimeError."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
-        import genlayer.gl.vm as gl_vm
-        from genlayer.py import calldata
+        import genlayer.vm as gl_vm
+        from genlayer import calldata
         from gltest.direct import wasi_mock
 
         def bad_leader():
@@ -318,8 +318,8 @@ class TestNondetRestrictions:
         """Trace and other non-cross-contract ops work inside run_nondet."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
-        import genlayer.gl.vm as gl_vm
-        from genlayer.py import calldata
+        import genlayer.vm as gl_vm
+        from genlayer import calldata
         from gltest.direct import wasi_mock
 
         def good_leader():
@@ -334,7 +334,7 @@ class TestNondetRestrictions:
         """Cross-contract calls outside run_nondet do not raise."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
-        from genlayer.py import calldata
+        from genlayer import calldata
         from gltest.direct import wasi_mock
 
         request = {
@@ -351,8 +351,8 @@ class TestNondetRestrictions:
         """_in_nondet flag is cleared even when leader_fn raises."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
-        import genlayer.gl.vm as gl_vm
-        from genlayer.py import calldata
+        import genlayer.vm as gl_vm
+        from genlayer import calldata
         from gltest.direct import wasi_mock
 
         vm = wasi_mock.get_vm()


### PR DESCRIPTION
## Summary
- add SDK compatibility helpers for GenVM v0.3 direct runner layout
- keep old `from genlayer import *` / `gl.*` contracts working in GLSim and direct mode
- synchronize message context across the v0.3 `genlayer.message` module and legacy `genlayer.gl` shim

## Verification
- `/tmp/genlayer-e2e-repro-testing-suite-venv/bin/python -m pytest tests/gltest_direct/test_sdk_loader.py tests/glsim/test_rpc_compat.py -q` (37 passed)

Required for the v0.6/v0.30 Studio E2E train: the current `v0.30-dev` branch contains the fee-aware GLSim tests but is missing this follow-up compatibility commit, which is why the central Studio tooling proof failed for genlayer-testing-suite.