### PR TITLE
feat(gltest): fee-aware transactions and backend-agnostic success assertions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
 on:
+  push:
+    branches:
+      - 'v*-dev'
   workflow_call:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -31,6 +34,8 @@ jobs:
 
       - name: Action | Run gltest tests
         run: uv run gltest tests/gltest/
+      - name: Run glsim tests
+        run: uv run gltest tests/glsim/
 
       # Unit tests only — integration tests here download the GenVM SDK.
       - name: Action | Run direct runner unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Setup | Install dependencies
-        run: uv sync --python ${{ matrix.python-version }}
+        run: uv sync --extra sim --python ${{ matrix.python-version }}
 
       - name: Action | Run gltest cli tests
         run: uv run gltest tests/gltest_cli/

--- a/gltest/assertions.py
+++ b/gltest/assertions.py
@@ -1,6 +1,62 @@
 import re
-from typing import Optional
+from typing import Any, Optional
 from genlayer_py.types import GenLayerTransaction
+
+try:
+    from genlayer_py.transactions import is_successful
+except ImportError:
+    is_successful = None
+
+
+ACCEPTED_STATUSES = {"ACCEPTED", "FINALIZED", "5", "7"}
+SUCCESS_RESULTS = {"FINISHED_WITH_RETURN", "1"}
+
+
+def _string_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", value)
+    return str(enum_value)
+
+
+def _has_accepted_status(result: GenLayerTransaction) -> bool:
+    status = _string_value(result.get("status_name", result.get("status")))
+    return status in ACCEPTED_STATUSES
+
+
+def _leader_receipt(result: GenLayerTransaction) -> Optional[dict]:
+    consensus_data = result.get("consensus_data")
+    if not isinstance(consensus_data, dict):
+        return None
+    leader_receipt = consensus_data.get("leader_receipt")
+    if isinstance(leader_receipt, dict):
+        return leader_receipt
+    if not isinstance(leader_receipt, list) or len(leader_receipt) == 0:
+        return None
+    if not isinstance(leader_receipt[0], dict):
+        return None
+    return leader_receipt[0]
+
+
+def _has_successful_execution(result: GenLayerTransaction) -> bool:
+    if not _has_accepted_status(result):
+        return False
+    if is_successful is not None:
+        try:
+            if is_successful(result):
+                return True
+        except Exception:
+            pass
+    execution_result = _string_value(
+        result.get("tx_execution_result_name", result.get("tx_execution_result"))
+    )
+    if execution_result in SUCCESS_RESULTS:
+        return True
+    leader_receipt = _leader_receipt(result)
+    return (
+        leader_receipt is not None
+        and leader_receipt.get("execution_result") == "SUCCESS"
+    )
 
 
 def tx_execution_succeeded(
@@ -8,25 +64,12 @@ def tx_execution_succeeded(
     match_std_out: Optional[str] = None,
     match_std_err: Optional[str] = None,
 ) -> bool:
-    if "consensus_data" not in result:
-        return False
-    if "leader_receipt" not in result["consensus_data"]:
-        return False
-    if len(result["consensus_data"]["leader_receipt"]) == 0:
-        return False
-
-    leader_receipt = result["consensus_data"]["leader_receipt"][0]
-
-    if "execution_result" not in leader_receipt:
-        return False
-
-    execution_result = leader_receipt["execution_result"]
-
-    if execution_result != "SUCCESS":
+    if not _has_successful_execution(result):
         return False
 
     if match_std_out is not None or match_std_err is not None:
-        if "genvm_result" not in leader_receipt:
+        leader_receipt = _leader_receipt(result)
+        if leader_receipt is None or "genvm_result" not in leader_receipt:
             return False
 
         genvm_result = leader_receipt["genvm_result"]

--- a/gltest/contracts/contract.py
+++ b/gltest/contracts/contract.py
@@ -1,3 +1,4 @@
+import inspect
 import types
 from eth_account.signers.local import LocalAccount
 from dataclasses import dataclass
@@ -10,10 +11,34 @@ from gltest.types import (
     TransactionContext,
 )
 from genlayer_py.types import SimConfig
-from typing import List, Any, Optional, Dict, Callable
+from typing import List, Any, Optional, Dict, Callable, Literal
 from gltest_cli.config.general import get_general_config
 from .contract_functions import ContractFunction
 from .stats_collector import StatsCollector, SimulationConfig
+
+
+def _fees_with_value(fees: Optional[Dict[str, Any]], fee_value: Optional[int]):
+    if fee_value is None:
+        return fees
+    return {**(fees or {}), "feeValue": fee_value}
+
+
+def _fee_kwargs(
+    call: Callable,
+    fees: Optional[Dict[str, Any]],
+    fee_value: Optional[int],
+):
+    if "fee_value" in inspect.signature(call).parameters:
+        return {"fees": fees, "fee_value": fee_value}
+    return {"fees": _fees_with_value(fees, fee_value)}
+
+
+def _wait_until_from_status(
+    status: TransactionStatus,
+) -> Literal["decided", "finalized"]:
+    if status == TransactionStatus.FINALIZED:
+        return "finalized"
+    return "decided"
 
 
 def read_contract_wrapper(
@@ -66,6 +91,9 @@ def write_contract_wrapper(
     def transact_method(
         value: int = 0,
         consensus_max_rotations: Optional[int] = None,
+        fees: Optional[Dict[str, Any]] = None,
+        fee_value: Optional[int] = None,
+        wait_until: Optional[Literal["decided", "finalized"]] = None,
         wait_transaction_status: TransactionStatus = TransactionStatus.ACCEPTED,
         wait_interval: Optional[int] = None,
         wait_retries: Optional[int] = None,
@@ -109,11 +137,12 @@ def write_contract_wrapper(
             consensus_max_rotations=consensus_max_rotations,
             leader_only=leader_only,
             args=args,
+            **_fee_kwargs(client.write_contract, fees, fee_value),
             sim_config=sim_config,
         )
         receipt = client.wait_for_transaction_receipt(
             transaction_hash=tx_hash,
-            status=wait_transaction_status,
+            wait_until=wait_until or _wait_until_from_status(wait_transaction_status),
             interval=actual_wait_interval,
             retries=actual_wait_retries,
         )
@@ -122,7 +151,9 @@ def write_contract_wrapper(
             for triggered_transaction in triggered_transactions:
                 client.wait_for_transaction_receipt(
                     transaction_hash=triggered_transaction,
-                    status=wait_triggered_transactions_status,
+                    wait_until=_wait_until_from_status(
+                        wait_triggered_transactions_status
+                    ),
                     interval=actual_wait_interval,
                     retries=actual_wait_retries,
                 )
@@ -223,6 +254,7 @@ class Contract:
         tx_hash: str,
         value: int = 0,
         wait_transaction_status: TransactionStatus = TransactionStatus.ACCEPTED,
+        wait_until: Optional[Literal["decided", "finalized"]] = None,
         wait_interval: Optional[int] = None,
         wait_retries: Optional[int] = None,
     ):
@@ -258,7 +290,7 @@ class Contract:
         )
         return client.wait_for_transaction_receipt(
             transaction_hash=tx_hash,
-            status=wait_transaction_status,
+            wait_until=wait_until or _wait_until_from_status(wait_transaction_status),
             interval=actual_wait_interval,
             retries=actual_wait_retries,
         )

--- a/gltest/contracts/contract_factory.py
+++ b/gltest/contracts/contract_factory.py
@@ -1,5 +1,6 @@
+import inspect
 from dataclasses import dataclass
-from typing import Type, Union, Optional, List, Any
+from typing import Type, Union, Optional, List, Any, Dict, Literal
 from pathlib import Path
 from eth_typing import (
     Address,
@@ -24,6 +25,26 @@ from gltest.exceptions import DeploymentError
 from gltest_cli.config.general import get_general_config
 from gltest.utils import extract_contract_address
 from gltest.types import TransactionContext
+
+
+def _fees_with_value(fees: Optional[Dict[str, Any]], fee_value: Optional[int]):
+    if fee_value is None:
+        return fees
+    return {**(fees or {}), "feeValue": fee_value}
+
+
+def _fee_kwargs(call, fees: Optional[Dict[str, Any]], fee_value: Optional[int]):
+    if "fee_value" in inspect.signature(call).parameters:
+        return {"fees": fees, "fee_value": fee_value}
+    return {"fees": _fees_with_value(fees, fee_value)}
+
+
+def _wait_until_from_status(
+    status: TransactionStatus,
+) -> Literal["decided", "finalized"]:
+    if status == TransactionStatus.FINALIZED:
+        return "finalized"
+    return "decided"
 
 
 @dataclass
@@ -110,6 +131,9 @@ class ContractFactory:
         args: Optional[List[CalldataEncodable]] = None,
         account: Optional[LocalAccount] = None,
         consensus_max_rotations: Optional[int] = None,
+        fees: Optional[Dict[str, Any]] = None,
+        fee_value: Optional[int] = None,
+        wait_until: Optional[Literal["decided", "finalized"]] = None,
         wait_interval: Optional[int] = None,
         wait_retries: Optional[int] = None,
         wait_transaction_status: TransactionStatus = TransactionStatus.ACCEPTED,
@@ -127,6 +151,9 @@ class ContractFactory:
             args=args,
             account=account,
             consensus_max_rotations=consensus_max_rotations,
+            fees=fees,
+            fee_value=fee_value,
+            wait_until=wait_until,
             wait_interval=wait_interval,
             wait_retries=wait_retries,
             wait_transaction_status=wait_transaction_status,
@@ -146,6 +173,9 @@ class ContractFactory:
         args: Optional[List[CalldataEncodable]] = None,
         account: Optional[LocalAccount] = None,
         consensus_max_rotations: Optional[int] = None,
+        fees: Optional[Dict[str, Any]] = None,
+        fee_value: Optional[int] = None,
+        wait_until: Optional[Literal["decided", "finalized"]] = None,
         wait_interval: Optional[int] = None,
         wait_retries: Optional[int] = None,
         wait_transaction_status: TransactionStatus = TransactionStatus.ACCEPTED,
@@ -189,11 +219,13 @@ class ContractFactory:
                 account=account,
                 consensus_max_rotations=consensus_max_rotations,
                 leader_only=leader_only,
+                **_fee_kwargs(client.deploy_contract, fees, fee_value),
                 sim_config=sim_config,
             )
             tx_receipt = client.wait_for_transaction_receipt(
                 transaction_hash=tx_hash,
-                status=wait_transaction_status,
+                wait_until=wait_until
+                or _wait_until_from_status(wait_transaction_status),
                 interval=actual_wait_interval,
                 retries=actual_wait_retries,
             )
@@ -202,7 +234,9 @@ class ContractFactory:
                 for triggered_transaction in triggered_transactions:
                     client.wait_for_transaction_receipt(
                         transaction_hash=triggered_transaction,
-                        status=wait_triggered_transactions_status,
+                        wait_until=_wait_until_from_status(
+                            wait_triggered_transactions_status
+                        ),
                         interval=actual_wait_interval,
                         retries=actual_wait_retries,
                     )

--- a/gltest/contracts/contract_functions.py
+++ b/gltest/contracts/contract_functions.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Optional, Dict, Any
+from typing import Callable, Optional, Dict, Any, Literal
 from gltest.types import TransactionStatus, TransactionHashVariant, TransactionContext
 
 
@@ -28,6 +28,9 @@ class ContractFunction:
         self,
         value: int = 0,
         consensus_max_rotations: Optional[int] = None,
+        fees: Optional[Dict[str, Any]] = None,
+        fee_value: Optional[int] = None,
+        wait_until: Optional[Literal["decided", "finalized"]] = None,
         wait_transaction_status: TransactionStatus = TransactionStatus.ACCEPTED,
         wait_interval: Optional[int] = None,
         wait_retries: Optional[int] = None,
@@ -41,6 +44,9 @@ class ContractFunction:
         return self.transact_method(
             value=value,
             consensus_max_rotations=consensus_max_rotations,
+            fees=fees,
+            fee_value=fee_value,
+            wait_until=wait_until,
             wait_transaction_status=wait_transaction_status,
             wait_interval=wait_interval,
             wait_retries=wait_retries,

--- a/gltest/direct/loader.py
+++ b/gltest/direct/loader.py
@@ -27,6 +27,19 @@ from .sdk_compat import (
     import_lazy,
 )
 
+_DIRECT_IGNORED_TX_KWARGS = {
+    "fees",
+    "fee_value",
+    "wait_until",
+    "wait_transaction_status",
+    "wait_interval",
+    "wait_retries",
+    "wait_triggered_transactions",
+    "wait_triggered_transactions_status",
+    "transaction_context",
+    "consensus_max_rotations",
+}
+
 
 def load_contract_class(
     contract_path: Path,
@@ -79,6 +92,7 @@ def deploy_contract(
 ) -> Any:
     """Deploy a contract and return an instance."""
     contract_path = Path(contract_path).resolve()
+    kwargs = _drop_direct_transaction_kwargs(kwargs)
 
     addr_hash = hashlib.sha256(str(contract_path).encode()).digest()[:20]
     vm._contract_address = addr_hash
@@ -98,6 +112,14 @@ def deploy_contract(
     instance = _allocate_contract(contract_cls, vm, *args, **kwargs)
 
     return _make_contract_proxy(instance)
+
+
+def _drop_direct_transaction_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in kwargs.items()
+        if key not in _DIRECT_IGNORED_TX_KWARGS
+    }
 
 
 def _patch_get_type_hints_for_pep695() -> None:
@@ -437,6 +459,7 @@ def _make_contract_proxy(instance: Any) -> Any:
             if not name.startswith('_') and callable(attr):
                 @functools.wraps(attr)
                 def _wrapped(*args: Any, **kwargs: Any) -> Any:
+                    kwargs = _drop_direct_transaction_kwargs(kwargs)
                     args, kwargs = _calldata_roundtrip_args(args, kwargs)
                     return attr(*args, **kwargs)
                 return _wrapped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.18.0,<0.19.0",
+    "genlayer-py>=0.18.0,<0.20.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"

--- a/tests/gltest/assertions/test_assertions.py
+++ b/tests/gltest/assertions/test_assertions.py
@@ -1,16 +1,22 @@
 from gltest.assertions import tx_execution_succeeded, tx_execution_failed
 
 GENLAYER_SUCCESS_TRANSACTION = {
-    "consensus_data": {"leader_receipt": [{"execution_result": "SUCCESS"}]}
+    "status": "ACCEPTED",
+    "consensus_data": {"leader_receipt": [{"execution_result": "SUCCESS"}]},
 }
 
 GENLAYER_FAILED_TRANSACTION = {
-    "consensus_data": {"leader_receipt": [{"execution_result": "ERROR"}]}
+    "status": "ACCEPTED",
+    "consensus_data": {"leader_receipt": [{"execution_result": "ERROR"}]},
 }
 
-GENLAYER_EMPTY_LEADER_RECEIPT = {"consensus_data": {"leader_receipt": []}}
+GENLAYER_EMPTY_LEADER_RECEIPT = {
+    "status": "ACCEPTED",
+    "consensus_data": {"leader_receipt": []},
+}
 
 GENLAYER_GENVM_TRANSACTION = {
+    "status": "ACCEPTED",
     "consensus_data": {
         "leader_receipt": [
             {
@@ -25,6 +31,7 @@ GENLAYER_GENVM_TRANSACTION = {
 }
 
 GENLAYER_GENVM_EMPTY_STDERR = {
+    "status": "ACCEPTED",
     "consensus_data": {
         "leader_receipt": [
             {
@@ -39,6 +46,7 @@ GENLAYER_GENVM_EMPTY_STDERR = {
 }
 
 GENLAYER_GENVM_NO_STDOUT = {
+    "status": "ACCEPTED",
     "consensus_data": {
         "leader_receipt": [
             {
@@ -50,6 +58,7 @@ GENLAYER_GENVM_NO_STDOUT = {
 }
 
 GENLAYER_GENVM_FAILED = {
+    "status": "ACCEPTED",
     "consensus_data": {
         "leader_receipt": [
             {
@@ -73,6 +82,48 @@ def test_with_successful_transaction():
     """
     assert tx_execution_succeeded(GENLAYER_SUCCESS_TRANSACTION) is True
     assert tx_execution_failed(GENLAYER_SUCCESS_TRANSACTION) is False
+
+
+def test_with_successful_testnet_transaction():
+    transaction = {
+        "status": "ACCEPTED",
+        "tx_execution_result_name": "FINISHED_WITH_RETURN",
+    }
+
+    assert tx_execution_succeeded(transaction) is True
+    assert tx_execution_failed(transaction) is False
+
+
+def test_with_successful_numeric_testnet_transaction():
+    transaction = {
+        "status": 5,
+        "tx_execution_result": 1,
+    }
+
+    assert tx_execution_succeeded(transaction) is True
+    assert tx_execution_failed(transaction) is False
+
+
+def test_undetermined_transaction_is_not_successful():
+    transaction = {
+        "status": "UNDETERMINED",
+        "tx_execution_result_name": "FINISHED_WITH_RETURN",
+        "consensus_data": {"leader_receipt": [{"execution_result": "SUCCESS"}]},
+    }
+
+    assert tx_execution_succeeded(transaction) is False
+    assert tx_execution_failed(transaction) is True
+
+
+def test_error_transaction_is_not_successful():
+    transaction = {
+        "status": "ACCEPTED",
+        "tx_execution_result_name": "FINISHED_WITH_ERROR",
+        "consensus_data": {"leader_receipt": [{"execution_result": "ERROR"}]},
+    }
+
+    assert tx_execution_succeeded(transaction) is False
+    assert tx_execution_failed(transaction) is True
 
 
 def test_with_failed_transaction():

--- a/tests/gltest/contracts/test_fee_params.py
+++ b/tests/gltest/contracts/test_fee_params.py
@@ -1,0 +1,105 @@
+from gltest.contracts.contract import Contract
+from gltest.contracts.contract_factory import ContractFactory
+
+
+class FakeGeneralConfig:
+    def get_default_wait_interval(self):
+        return 1
+
+    def get_default_wait_retries(self):
+        return 1
+
+    def get_leader_only(self):
+        return False
+
+    def check_studio_based_rpc(self):
+        return False
+
+
+class FakeClient:
+    def __init__(self):
+        self.write_contract_calls = []
+        self.deploy_contract_calls = []
+        self.wait_for_transaction_receipt_calls = []
+
+    def write_contract(self, **kwargs):
+        self.write_contract_calls.append(kwargs)
+        return "0xwrite"
+
+    def deploy_contract(self, **kwargs):
+        self.deploy_contract_calls.append(kwargs)
+        return "0xdeploy"
+
+    def wait_for_transaction_receipt(self, **kwargs):
+        self.wait_for_transaction_receipt_calls.append(kwargs)
+        return {
+            "status": "ACCEPTED",
+            "consensus_data": {"leader_receipt": [{"execution_result": "SUCCESS"}]},
+        }
+
+
+def test_transact_threads_fee_params_to_sdk(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr("gltest.contracts.contract.get_gl_client", lambda: client)
+    monkeypatch.setattr(
+        "gltest.contracts.contract.get_general_config", lambda: FakeGeneralConfig()
+    )
+    contract = Contract.new(
+        address="0x123",
+        schema={"methods": {"set_value": {"readonly": False}}},
+    )
+    fees = {
+        "distribution": {"leaderTimeunitsAllocation": 1},
+        "messageAllocations": [],
+    }
+
+    receipt = contract.set_value([1]).transact(
+        fees=fees,
+        fee_value=123,
+        wait_until="finalized",
+    )
+
+    assert receipt["status"] == "ACCEPTED"
+    assert client.write_contract_calls[0]["fees"] == {
+        **fees,
+        "feeValue": 123,
+    }
+    assert client.wait_for_transaction_receipt_calls[0] == {
+        "transaction_hash": "0xwrite",
+        "wait_until": "finalized",
+        "interval": 1,
+        "retries": 1,
+    }
+
+
+def test_deploy_threads_fee_params_to_sdk(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr("gltest.contracts.contract_factory.get_gl_client", lambda: client)
+    monkeypatch.setattr(
+        "gltest.contracts.contract_factory.get_general_config",
+        lambda: FakeGeneralConfig(),
+    )
+    factory = ContractFactory(contract_name="Example", contract_code="class Example: pass")
+    fees = {
+        "distribution": {"leaderTimeunitsAllocation": 1},
+        "messageAllocations": [],
+        "feeValue": 100,
+    }
+
+    receipt = factory.deploy_contract_tx(
+        args=["hello"],
+        fees=fees,
+        fee_value=250,
+    )
+
+    assert receipt["status"] == "ACCEPTED"
+    assert client.deploy_contract_calls[0]["fees"] == {
+        **fees,
+        "feeValue": 250,
+    }
+    assert client.wait_for_transaction_receipt_calls[0] == {
+        "transaction_hash": "0xdeploy",
+        "wait_until": "decided",
+        "interval": 1,
+        "retries": 1,
+    }

--- a/tests/gltest_direct/test_contract_deployment.py
+++ b/tests/gltest_direct/test_contract_deployment.py
@@ -28,6 +28,25 @@ class TestContractDeployment:
         storage.update_storage("new value")
         assert storage.get_storage() == "new value"
 
+    def test_direct_mode_ignores_fee_kwargs(self, direct_vm, direct_deploy):
+        """Fee-aware dev-env tests do not crash in gasless direct mode."""
+        fees = {
+            "distribution": {"leaderTimeunitsAllocation": 1},
+            "messageAllocations": [],
+            "feeValue": 10,
+        }
+        storage = direct_deploy(
+            str(CONTRACTS_DIR / "storage.py"),
+            "initial value",
+            fees=fees,
+            fee_value=10,
+            wait_until="decided",
+        )
+
+        storage.update_storage("new value", fees=fees, fee_value=10)
+
+        assert storage.get_storage() == "new value"
+
     def test_deploy_user_storage_with_sender(self, direct_vm, direct_deploy):
         """UserStorage respects gl.message.sender_address."""
         user_storage = direct_deploy(str(CONTRACTS_DIR / "user_storage.py"))


### PR DESCRIPTION
Closes the 'gltest cannot test fee-enabled backends at all' gap from the fee audit.

- `transact_method`/`deploy` accept `fees` / `fee_value` / `wait_until` and thread them verbatim to genlayer-py (SDK resolves defaults — gltest does not re-implement estimation). Deprecated `status=` kwarg replaced by `wait_until 'decided'/'finalized'`.
- Direct/sim mode ignores fee kwargs gracefully (gasless by design) — dev-env-targeted tests run unchanged in direct mode.
- `tx_execution_succeeded` now requires consensus acceptance and recognizes both receipt shapes (Studio `leader_receipt.execution_result == SUCCESS`; testnet `tx_execution_result_name == FINISHED_WITH_RETURN`), preferring `genlayer_py.transactions.is_successful`. An UNDETERMINED tx with a leader FINISHED_WITH_RETURN result is now correctly **False** — the leader's result exists even without a validator majority.
- genlayer-py dependency relaxed to `<0.20.0` (fee-aware 0.19 line).

209 tests green (the 22 example-suite failures pre-exist on base — missing contracts/ scaffold, environmental). Depends on genlayerlabs/genlayer-py#90 for wait_until/is_successful.