### PR TITLE
docs: add branching guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,19 +29,11 @@ Have ideas for new features or use cases? We're eager to hear them! But first:
 
 ## Branch model
 
-This repo uses a branch-per-major release model. There is no `main`.
-
-- **`v0.29`** — current stable major (semver-zero, so 0.29 IS the major; 0.30 would be a major bump that gets its own branch).
-- **`v<next>-dev`** — when next-major work is in progress.
-- Default branch on github.com is the current stable.
-
-If you have a `main` branch from a previous checkout:
-
-```sh
-git checkout v0.29
-git branch -D main
-git remote prune origin
-```
+See [docs/BRANCHING.md](docs/BRANCHING.md) for the current release-train model.
+In short: independently releasable work may target the stable branch directly;
+multi-feature or cross-repo train work uses the active `*-dev` integration
+branch and is promoted to the matching stable branch when ready. `main` is only
+the default/static GitHub branch.
 
 ## Releases
 
@@ -161,7 +153,7 @@ The project uses automated semantic versioning based on commit messages:
 | `feat!:`, `fix!:`, or `BREAKING CHANGE:` | **Major** version bump | 1.0.0 → 2.0.0 |
 | `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:` | **No** version bump | Version stays the same |
 
-**Important**: Never manually edit version numbers in `pyproject.toml` or other files. The release automation will handle all version updates automatically when PRs are merged to the main branch.
+**Important**: Never manually edit version numbers in `pyproject.toml` or other files. Releases are cut from the stable branch using the release automation described above.
 
 ### Improving Documentation
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,58 @@
+# Branching and Release Trains
+
+This repo follows the GenLayer release-train model.
+
+## Current Train
+
+- Current stable branch: `v0.29`
+- Active integration branch: `v0.30-dev`
+- Next stable target: `v0.30`
+- `main`: default/static branch alias for the active integration branch
+
+## Stable Branches
+
+Stable branches are long-lived release lines. For semver-zero packages, each
+minor line is treated as the release line, for example `v0.29` or `v0.30`.
+
+PRs may target a stable branch directly when the merged result should be
+releasable immediately. This is appropriate for bug fixes, small non-breaking
+features, isolated release fixes, or a breaking change that is intentionally
+shipping as the next version by itself.
+
+Stable branches must remain releasable. PRs into stable branches are expected to
+pass the required cross-repo `E2E Tests` gate before merge.
+
+## Integration Branches
+
+Integration branches are optional. Use one when multiple changes need to
+accumulate before release, especially for cross-repo work, dependent features,
+breaking changes that must ship together, or a train that needs advisory E2E
+while still expected to be red.
+
+Integration branches are named after the target stable branch plus `-dev`, for
+example `v0.30-dev`. Feature PRs for that train target the integration branch.
+
+PRs into integration branches may run `E2E Tests` as advisory checks. They are
+not the release gate.
+
+## Promotion and Release
+
+When an integration train is ready, open a promotion PR from the integration
+branch to the matching stable branch, for example `v0.30-dev` to `v0.30`.
+
+That promotion PR is the release-readiness gate and must pass required
+cross-repo `E2E Tests`. The actual package release is cut from the stable branch
+using a version tag after the stable branch is ready.
+
+## `main`
+
+`main` exists for GitHub UX and tools that require a stable default branch. It is
+not a release branch and it is not the integration target.
+
+This repo keeps `main` forwarded to the active integration branch using
+automation. PRs opened against `main` are automatically retargeted to the branch
+listed in `support/ci/ACTIVE_DEV_BRANCH`.
+
+When changing the active integration branch, update
+`support/ci/ACTIVE_DEV_BRANCH`, the repo docs, and the corresponding
+`genlayer-e2e` release-train matrix in the same change set.


### PR DESCRIPTION
## Summary

- add docs/BRANCHING.md describing stable branches, optional integration branches, promotion PRs, E2E gates, releases, and main behavior
- replace stale contributor wording that said there is no main/default branch is stable
- update stale release wording from merge-to-main to tag-from-stable

## Testing

- Docs-only change; no test suite run.