### PR TITLE
fix: support fee profile policy fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,14 @@ gltest --fee-profile artifacts/fee-profile.json
 gltest --fee-profile artifacts/fee-profile.json --fee-profile-headroom 1.5
 ```
 
-`--fee-profile` writes JSON that can be passed verbatim as `suggestions` to
-`createTransactionKit` from `@genlayer/transaction-kit`. The optional
-`--fee-profile-headroom` multiplier defaults to `1.25`. Each value is the
-maximum observed consumed fee across the session multiplied by headroom, rounded
-up, and emitted as a decimal string.
+`--fee-profile` writes JSON that can be used as developer fee suggestions by
+transaction-kit, genlayer-js, genlayer-py, or CLI-based submission flows. The optional
+`--fee-profile-headroom` multiplier defaults to `1.25`. Fee and time-unit
+values are multiplied by headroom, rounded up, and emitted as decimal strings.
+When the same method is observed in multiple tests, the profile records the
+maximum observed value for each field across all of those branches.
+`rotationsPerRound` is recorded exactly because it is a posture choice rather
+than a consumed fee amount.
 
 ```json
 {
@@ -240,13 +243,19 @@ up, and emitted as a decimal string.
   "network": "localnet",
   "measuredAt": "2026-06-10T12:00:00Z",
   "deploy": {
+    "leaderTimeunitsAllocation": "125",
+    "validatorTimeunitsAllocation": "250",
     "executionBudgetPerRound": "625000",
-    "totalMessageFees": "0"
+    "totalMessageFees": "0",
+    "rotationsPerRound": "0"
   },
   "methods": {
     "create_bet": {
+      "leaderTimeunitsAllocation": "125",
+      "validatorTimeunitsAllocation": "250",
       "executionBudgetPerRound": "312500",
-      "totalMessageFees": "12500"
+      "totalMessageFees": "12500",
+      "rotationsPerRound": "0"
     }
   }
 }
@@ -255,9 +264,9 @@ up, and emitted as a decimal string.
 Fee profiling is currently measurable on Studio-based networks whose receipts
 include consumed fee data. Testnet receipts do not expose consumed fees yet, and
 direct/sim mode does not go through these receipt paths. Time-unit allocations
-are not measurable from backend receipts, so `leaderTimeunitsAllocation` and
-`validatorTimeunitsAllocation` are intentionally omitted; downstream presets or
-network defaults should supply them.
+are recorded from the submitted fee distribution when the backend receipt
+includes it. Live price caps and `feeValue` are intentionally omitted so the SDK
+can quote them from the current network policy at transaction time.
 
 ### Assertions
 

--- a/gltest/artifacts/contract.py
+++ b/gltest/artifacts/contract.py
@@ -104,16 +104,18 @@ def _extract_contract_name_from_file(file_path: Path) -> str:
     raise ValueError(f"No valid contract class found in {file_path}")
 
 
+def _attribute_path(node: ast.expr) -> list[str]:
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):
+        return [*_attribute_path(node.value), node.attr]
+    return []
+
+
 def _is_genlayer_contract_base(base: ast.expr) -> bool:
-    """Return True for ``gl.contract.Contract`` inheritance."""
-    return (
-        isinstance(base, ast.Attribute)
-        and base.attr == "Contract"
-        and isinstance(base.value, ast.Attribute)
-        and base.value.attr == "contract"
-        and isinstance(base.value.value, ast.Name)
-        and base.value.value.id == "gl"
-    )
+    """Return True for supported GenLayer contract base classes."""
+    path = _attribute_path(base)
+    return path in (["gl", "contract", "Contract"], ["gl", "Contract"])
 
 
 def _create_contract_definition(

--- a/gltest/contracts/contract.py
+++ b/gltest/contracts/contract.py
@@ -16,6 +16,7 @@ from gltest_cli.config.general import get_general_config
 from gltest.fees import maybe_record_fee_observation
 from .contract_functions import ContractFunction
 from .stats_collector import StatsCollector, SimulationConfig
+from .wait import wait_for_transaction_receipt, wait_until_from_status
 
 
 def _fees_with_value(fees: Optional[Dict[str, Any]], fee_value: Optional[int]):
@@ -32,14 +33,6 @@ def _fee_kwargs(
     if "fee_value" in inspect.signature(call).parameters:
         return {"fees": fees, "fee_value": fee_value}
     return {"fees": _fees_with_value(fees, fee_value)}
-
-
-def _wait_until_from_status(
-    status: TransactionStatus,
-) -> Literal["decided", "finalized"]:
-    if status == TransactionStatus.FINALIZED:
-        return "finalized"
-    return "decided"
 
 
 def read_contract_wrapper(
@@ -141,9 +134,10 @@ def write_contract_wrapper(
             **_fee_kwargs(client.write_contract, fees, fee_value),
             sim_config=sim_config,
         )
-        receipt = client.wait_for_transaction_receipt(
+        receipt = wait_for_transaction_receipt(
+            client,
             transaction_hash=tx_hash,
-            wait_until=wait_until or _wait_until_from_status(wait_transaction_status),
+            wait_until=wait_until or wait_until_from_status(wait_transaction_status),
             interval=actual_wait_interval,
             retries=actual_wait_retries,
         )
@@ -153,9 +147,10 @@ def write_contract_wrapper(
         if wait_triggered_transactions:
             triggered_transactions = receipt.get("triggered_transactions", [])
             for triggered_transaction in triggered_transactions:
-                client.wait_for_transaction_receipt(
+                wait_for_transaction_receipt(
+                    client,
                     transaction_hash=triggered_transaction,
-                    wait_until=_wait_until_from_status(
+                    wait_until=wait_until_from_status(
                         wait_triggered_transactions_status
                     ),
                     interval=actual_wait_interval,
@@ -292,9 +287,10 @@ class Contract:
             account=self.account,
             value=value,
         )
-        return client.wait_for_transaction_receipt(
+        return wait_for_transaction_receipt(
+            client,
             transaction_hash=tx_hash,
-            wait_until=wait_until or _wait_until_from_status(wait_transaction_status),
+            wait_until=wait_until or wait_until_from_status(wait_transaction_status),
             interval=actual_wait_interval,
             retries=actual_wait_retries,
         )

--- a/gltest/contracts/contract_factory.py
+++ b/gltest/contracts/contract_factory.py
@@ -26,6 +26,7 @@ from gltest_cli.config.general import get_general_config
 from gltest.fees import maybe_record_fee_observation
 from gltest.utils import extract_contract_address
 from gltest.types import TransactionContext
+from .wait import wait_for_transaction_receipt, wait_until_from_status
 
 
 def _fees_with_value(fees: Optional[Dict[str, Any]], fee_value: Optional[int]):
@@ -38,14 +39,6 @@ def _fee_kwargs(call, fees: Optional[Dict[str, Any]], fee_value: Optional[int]):
     if "fee_value" in inspect.signature(call).parameters:
         return {"fees": fees, "fee_value": fee_value}
     return {"fees": _fees_with_value(fees, fee_value)}
-
-
-def _wait_until_from_status(
-    status: TransactionStatus,
-) -> Literal["decided", "finalized"]:
-    if status == TransactionStatus.FINALIZED:
-        return "finalized"
-    return "decided"
 
 
 @dataclass
@@ -223,10 +216,11 @@ class ContractFactory:
                 **_fee_kwargs(client.deploy_contract, fees, fee_value),
                 sim_config=sim_config,
             )
-            tx_receipt = client.wait_for_transaction_receipt(
+            tx_receipt = wait_for_transaction_receipt(
+                client,
                 transaction_hash=tx_hash,
                 wait_until=wait_until
-                or _wait_until_from_status(wait_transaction_status),
+                or wait_until_from_status(wait_transaction_status),
                 interval=actual_wait_interval,
                 retries=actual_wait_retries,
             )
@@ -234,9 +228,10 @@ class ContractFactory:
             if wait_triggered_transactions:
                 triggered_transactions = tx_receipt.get("triggered_transactions", [])
                 for triggered_transaction in triggered_transactions:
-                    client.wait_for_transaction_receipt(
+                    wait_for_transaction_receipt(
+                        client,
                         transaction_hash=triggered_transaction,
-                        wait_until=_wait_until_from_status(
+                        wait_until=wait_until_from_status(
                             wait_triggered_transactions_status
                         ),
                         interval=actual_wait_interval,

--- a/gltest/contracts/wait.py
+++ b/gltest/contracts/wait.py
@@ -1,0 +1,54 @@
+import inspect
+from typing import Callable, Literal
+
+from gltest.types import TransactionStatus
+
+
+def wait_until_from_status(
+    status: TransactionStatus,
+) -> Literal["decided", "finalized"]:
+    if status == TransactionStatus.FINALIZED:
+        return "finalized"
+    return "decided"
+
+
+def _status_from_wait_until(wait_until: Literal["decided", "finalized"]):
+    if wait_until == "finalized":
+        return TransactionStatus.FINALIZED
+    return TransactionStatus.ACCEPTED
+
+
+def _accepts_var_kwargs(call: Callable) -> bool:
+    return any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in inspect.signature(call).parameters.values()
+    )
+
+
+def wait_for_transaction_receipt(
+    client,
+    *,
+    transaction_hash: str,
+    wait_until: Literal["decided", "finalized"],
+    interval: int,
+    retries: int,
+):
+    call = client.wait_for_transaction_receipt
+    parameters = inspect.signature(call).parameters
+    kwargs = {
+        "transaction_hash": transaction_hash,
+        "interval": interval,
+        "retries": retries,
+    }
+
+    if "wait_until" in parameters or (
+        "status" not in parameters and _accepts_var_kwargs(call)
+    ):
+        kwargs["wait_until"] = wait_until
+    else:
+        kwargs["status"] = _status_from_wait_until(wait_until)
+
+    if "full_transaction" in parameters:
+        kwargs["full_transaction"] = True
+
+    return call(**kwargs)

--- a/gltest/fees/profile.py
+++ b/gltest/fees/profile.py
@@ -8,10 +8,20 @@ from typing import Any, Dict, Optional
 from gltest.logging import logger
 from gltest_cli.config.general import get_general_config
 
-FEE_KEYS = ("executionBudgetPerRound", "totalMessageFees")
+FEE_KEYS = (
+    "leaderTimeunitsAllocation",
+    "validatorTimeunitsAllocation",
+    "executionBudgetPerRound",
+    "totalMessageFees",
+    "rotationsPerRound",
+)
 CONSUMED_KEY_MAPPING = {
     "executionBudgetPerRound": "executionConsumed",
     "totalMessageFees": "messageFeesConsumed",
+}
+ALLOCATION_KEY_MAPPING = {
+    "leaderTimeunitsAllocation": "leaderTimeunitsAllocation",
+    "validatorTimeunitsAllocation": "validatorTimeunitsAllocation",
 }
 
 
@@ -62,34 +72,163 @@ class FeeProfileCollector:
         try:
             if not receipt:
                 return None
-            fees = receipt.get("fees")
-            if not fees:
+            legacy_observation = self._extract_legacy_fee_observation(receipt)
+            if legacy_observation is not None:
+                return legacy_observation
+
+            accounting = self._extract_fee_accounting(receipt)
+            if accounting is None:
                 return None
-            consumed = fees.get("consumed")
-            if not consumed:
-                return None
-            return {
-                output_key: int(consumed[consumed_key])
-                for output_key, consumed_key in CONSUMED_KEY_MAPPING.items()
-            }
+
+            observation = self._extract_distribution_observation(accounting)
+            report = self._dict_or_none(accounting.get("execution_fee_report")) or {}
+            execution_fee_report_total = self._int_value(
+                report.get("totalEstimatedFee")
+            )
+            execution_consumed = self._int_value(
+                accounting.get("execution_fee_consumed")
+            )
+            message_consumed = self._int_value(accounting.get("message_fee_consumed"))
+            genvm_message_consumed = self._int_value(
+                accounting.get("genvm_message_fee_consumed")
+            )
+
+            observation.update(
+                {
+                    "executionBudgetPerRound": execution_consumed
+                    + execution_fee_report_total,
+                    "totalMessageFees": max(
+                        message_consumed, genvm_message_consumed
+                    ),
+                }
+            )
+            return observation
         except Exception as e:
             if not self._warned_malformed:
                 logger.warning("Failed to record fee profile observation: %s", e)
                 self._warned_malformed = True
             return None
 
+    def _extract_legacy_fee_observation(
+        self, receipt: Dict[str, Any]
+    ) -> Optional[Dict[str, int]]:
+        fees = self._dict_or_none(receipt.get("fees"))
+        if not fees:
+            return None
+        consumed = self._dict_or_none(fees.get("consumed"))
+        if not consumed:
+            return None
+        observation = {
+            output_key: int(consumed[consumed_key])
+            for output_key, consumed_key in CONSUMED_KEY_MAPPING.items()
+        }
+        distribution = self._dict_or_none(fees.get("distribution"))
+        if distribution:
+            observation.update(self._allocation_observation(distribution))
+        return observation
+
+    def _extract_distribution_observation(
+        self, accounting: Dict[str, Any]
+    ) -> Dict[str, int]:
+        for candidate in self._distribution_candidates(accounting):
+            distribution = self._dict_or_none(candidate)
+            if distribution:
+                return self._allocation_observation(distribution)
+        return {}
+
+    def _distribution_candidates(self, accounting: Dict[str, Any]):
+        yield accounting.get("fees_distribution")
+        yield accounting.get("feesDistribution")
+
+        preset = self._dict_or_none(accounting.get("recommended_fee_preset"))
+        if preset:
+            yield preset.get("distribution")
+
+        camel_preset = self._dict_or_none(accounting.get("recommendedFeePreset"))
+        if camel_preset:
+            yield camel_preset.get("distribution")
+
+    def _allocation_observation(self, distribution: Dict[str, Any]) -> Dict[str, int]:
+        observation = {
+            output_key: self._int_value(distribution.get(source_key))
+            for output_key, source_key in ALLOCATION_KEY_MAPPING.items()
+            if distribution.get(source_key) is not None
+        }
+        rotations = distribution.get("rotations")
+        if isinstance(rotations, list) and rotations:
+            observation["rotationsPerRound"] = max(
+                self._int_value(rotation) for rotation in rotations
+            )
+        return observation
+
+    def _extract_fee_accounting(
+        self, receipt: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        for candidate in self._fee_accounting_candidates(receipt):
+            accounting = self._dict_or_none(candidate)
+            if accounting:
+                return accounting
+        return None
+
+    def _fee_accounting_candidates(self, receipt: Dict[str, Any]):
+        yield receipt.get("fee_accounting")
+        yield receipt.get("feeAccounting")
+
+        data = self._dict_or_none(receipt.get("data"))
+        if data:
+            yield data.get("fee_accounting")
+            yield data.get("feeAccounting")
+
+        genvm_result = self._dict_or_none(receipt.get("genvm_result"))
+        if genvm_result:
+            yield genvm_result.get("fee_accounting")
+            yield genvm_result.get("feeAccounting")
+
+        consensus_data = self._dict_or_none(receipt.get("consensus_data"))
+        if not consensus_data:
+            return
+
+        leader_receipt = consensus_data.get("leader_receipt")
+        leader_receipts = (
+            leader_receipt
+            if isinstance(leader_receipt, list)
+            else [leader_receipt]
+        )
+        for item in leader_receipts:
+            receipt_item = self._dict_or_none(item)
+            if not receipt_item:
+                continue
+            yield receipt_item.get("fee_accounting")
+            yield receipt_item.get("feeAccounting")
+            leader_genvm_result = self._dict_or_none(receipt_item.get("genvm_result"))
+            if leader_genvm_result:
+                yield leader_genvm_result.get("fee_accounting")
+                yield leader_genvm_result.get("feeAccounting")
+
+    @staticmethod
+    def _dict_or_none(value: Any) -> Optional[Dict[str, Any]]:
+        return value if isinstance(value, dict) else None
+
+    @staticmethod
+    def _int_value(value: Any) -> int:
+        return int(value or 0)
+
     @staticmethod
     def _record_max(current: Dict[str, int], observation: Dict[str, int]) -> None:
         for key in FEE_KEYS:
+            if key not in observation:
+                continue
             current[key] = max(current.get(key, 0), observation[key])
 
     @staticmethod
     def _apply_headroom(values: Dict[str, int], headroom: float) -> Dict[str, str]:
         multiplier = Decimal(str(headroom))
-        # The backend only reports consumed fee amounts, not consumed time-unit
-        # allocations, so leader/validator allocation suggestions are omitted.
         return {
-            key: str(math.ceil(Decimal(value) * multiplier))
+            key: str(
+                value
+                if key == "rotationsPerRound"
+                else math.ceil(Decimal(value) * multiplier)
+            )
             for key, value in values.items()
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.19.0,<0.20.0",
+    "genlayer-py>=0.18.0,<0.20.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pytest",
-    "genlayer-py>=0.18.0,<0.20.0",
+    "genlayer-py>=0.19.0,<0.20.0",
     "colorama>=0.4.6",
     "pyyaml",
     "python-dotenv"

--- a/tests/gltest/artifact/contracts/current_style_contract.py
+++ b/tests/gltest/artifact/contracts/current_style_contract.py
@@ -1,0 +1,18 @@
+# { "Depends": "py-genlayer:latest" }
+
+import genlayer as gl
+
+
+class CurrentStyleContract(gl.Contract):
+    storage: str
+
+    def __init__(self, initial_storage: str):
+        self.storage = initial_storage
+
+    @gl.public.view
+    def get_storage(self) -> str:
+        return self.storage
+
+    @gl.public.write
+    def update_storage(self, new_storage: str) -> None:
+        self.storage = new_storage

--- a/tests/gltest/artifact/test_contract_definition.py
+++ b/tests/gltest/artifact/test_contract_definition.py
@@ -1,6 +1,7 @@
 import pytest
 from gltest.artifacts.contract import (
     find_contract_definition_from_name,
+    find_contract_definition_from_path,
     compute_contract_code,
 )
 from gltest_cli.config.general import get_general_config
@@ -53,3 +54,26 @@ def test_class_is_not_intelligent_contract():
 
     with pytest.raises(FileNotFoundError):
         _ = find_contract_definition_from_name("NotICContract")
+
+
+def test_current_style_gl_contract_base():
+    general_config = get_general_config()
+    general_config.set_contracts_dir(Path("tests/gltest/artifact/contracts"))
+
+    contract_definition = find_contract_definition_from_name("CurrentStyleContract")
+
+    assert contract_definition.contract_name == "CurrentStyleContract"
+    assert contract_definition.main_file_path == (
+        Path("tests/gltest/artifact/contracts") / "current_style_contract.py"
+    )
+
+
+def test_current_style_gl_contract_base_from_path():
+    general_config = get_general_config()
+    general_config.set_contracts_dir(Path("tests/gltest/artifact/contracts"))
+
+    contract_definition = find_contract_definition_from_path(
+        "current_style_contract.py"
+    )
+
+    assert contract_definition.contract_name == "CurrentStyleContract"

--- a/tests/gltest/contracts/test_fee_params.py
+++ b/tests/gltest/contracts/test_fee_params.py
@@ -1,5 +1,7 @@
 from gltest.contracts.contract import Contract
 from gltest.contracts.contract_factory import ContractFactory
+from gltest.contracts.wait import wait_for_transaction_receipt
+from gltest.types import TransactionStatus
 
 
 class FakeGeneralConfig:
@@ -36,6 +38,51 @@ class FakeClient:
             "status": "ACCEPTED",
             "consensus_data": {"leader_receipt": [{"execution_result": "SUCCESS"}]},
         }
+
+
+class OldWaitClient:
+    def __init__(self):
+        self.wait_for_transaction_receipt_calls = []
+
+    def wait_for_transaction_receipt(
+        self,
+        transaction_hash,
+        status=TransactionStatus.ACCEPTED,
+        interval=3000,
+        retries=50,
+        full_transaction=False,
+    ):
+        self.wait_for_transaction_receipt_calls.append(
+            {
+                "transaction_hash": transaction_hash,
+                "status": status,
+                "interval": interval,
+                "retries": retries,
+                "full_transaction": full_transaction,
+            }
+        )
+        return {"status": "ACCEPTED"}
+
+
+def test_wait_helper_supports_old_sdk_status_signature():
+    client = OldWaitClient()
+
+    receipt = wait_for_transaction_receipt(
+        client,
+        transaction_hash="0xwrite",
+        wait_until="decided",
+        interval=1,
+        retries=2,
+    )
+
+    assert receipt["status"] == "ACCEPTED"
+    assert client.wait_for_transaction_receipt_calls[0] == {
+        "transaction_hash": "0xwrite",
+        "status": TransactionStatus.ACCEPTED,
+        "interval": 1,
+        "retries": 2,
+        "full_transaction": True,
+    }
 
 
 def test_transact_threads_fee_params_to_sdk(monkeypatch):

--- a/tests/gltest/fees/test_fee_profile.py
+++ b/tests/gltest/fees/test_fee_profile.py
@@ -30,6 +30,38 @@ def fee_receipt(execution_consumed, message_fees_consumed):
     }
 
 
+def studio_fee_accounting_receipt(
+    *,
+    execution_consumed=100,
+    execution_report_total=200,
+    message_consumed=10,
+    genvm_message_consumed=7,
+    leader_timeunits=100,
+    validator_timeunits=200,
+    rotations=None,
+):
+    if rotations is None:
+        rotations = [0]
+    return {
+        "status": "ACCEPTED",
+        "data": {
+            "fee_accounting": {
+                "fees_distribution": {
+                    "leaderTimeunitsAllocation": str(leader_timeunits),
+                    "validatorTimeunitsAllocation": str(validator_timeunits),
+                    "rotations": [str(rotation) for rotation in rotations],
+                },
+                "execution_fee_consumed": str(execution_consumed),
+                "message_fee_consumed": str(message_consumed),
+                "genvm_message_fee_consumed": str(genvm_message_consumed),
+                "execution_fee_report": {
+                    "totalEstimatedFee": str(execution_report_total),
+                },
+            },
+        },
+    }
+
+
 class FakeGeneralConfig:
     def __init__(self, fee_profile_path=None):
         self.fee_profile_path = fee_profile_path
@@ -89,10 +121,14 @@ def test_collector_records_max_and_applies_headroom_with_big_int():
     assert profile["version"] == 1
     assert profile["network"] == "localnet"
     assert profile["deploy"] == {
+        "leaderTimeunitsAllocation": "125",
+        "validatorTimeunitsAllocation": "250",
         "executionBudgetPerRound": "127",
         "totalMessageFees": "13",
     }
     assert profile["methods"]["create_bet"] == {
+        "leaderTimeunitsAllocation": "125",
+        "validatorTimeunitsAllocation": "250",
         "executionBudgetPerRound": "125000000000000000000",
         "totalMessageFees": "0",
     }
@@ -118,7 +154,88 @@ def test_message_fee_zero_is_recorded():
     assert profile["methods"]["create_bet"]["totalMessageFees"] == "0"
 
 
-def test_profile_shape_omits_deploy_when_unobserved_and_time_unit_keys():
+def test_current_studio_fee_accounting_shape_is_recorded():
+    collector = FeeProfileCollector()
+    collector.record_method("resolve_bet", studio_fee_accounting_receipt())
+
+    profile = collector.build_profile(network="localnet", headroom=1.25)
+
+    assert profile["methods"]["resolve_bet"] == {
+        "leaderTimeunitsAllocation": "125",
+        "validatorTimeunitsAllocation": "250",
+        "executionBudgetPerRound": "375",
+        "totalMessageFees": "13",
+        "rotationsPerRound": "0",
+    }
+
+
+def test_method_profile_uses_per_field_maxima_across_branches():
+    collector = FeeProfileCollector()
+    collector.record_method(
+        "complex_action",
+        studio_fee_accounting_receipt(
+            execution_consumed=500,
+            execution_report_total=100,
+            message_consumed=0,
+            genvm_message_consumed=0,
+            leader_timeunits=100,
+            validator_timeunits=200,
+            rotations=[0],
+        ),
+    )
+    collector.record_method(
+        "complex_action",
+        studio_fee_accounting_receipt(
+            execution_consumed=100,
+            execution_report_total=100,
+            message_consumed=800,
+            genvm_message_consumed=750,
+            leader_timeunits=80,
+            validator_timeunits=150,
+            rotations=[1],
+        ),
+    )
+
+    profile = collector.build_profile(network="localnet", headroom=1.0)
+
+    assert profile["methods"]["complex_action"] == {
+        "leaderTimeunitsAllocation": "100",
+        "validatorTimeunitsAllocation": "200",
+        "executionBudgetPerRound": "600",
+        "totalMessageFees": "800",
+        "rotationsPerRound": "1",
+    }
+
+
+def test_nested_leader_fee_accounting_shape_is_recorded():
+    collector = FeeProfileCollector()
+    collector.record_method(
+        "resolve_bet",
+        {
+            "consensus_data": {
+                "leader_receipt": [
+                    {
+                        "genvm_result": {
+                            "fee_accounting": {
+                                "execution_fee_consumed": "50",
+                                "genvm_message_fee_consumed": "9",
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+    )
+
+    profile = collector.build_profile(network="localnet", headroom=1.0)
+
+    assert profile["methods"]["resolve_bet"] == {
+        "executionBudgetPerRound": "50",
+        "totalMessageFees": "9",
+    }
+
+
+def test_profile_shape_includes_time_unit_keys_when_available():
     collector = FeeProfileCollector()
     collector.record_method("create_bet", fee_receipt(10, 5))
 
@@ -127,12 +244,12 @@ def test_profile_shape_omits_deploy_when_unobserved_and_time_unit_keys():
     assert set(profile) == {"version", "network", "measuredAt", "methods"}
     assert profile["methods"] == {
         "create_bet": {
+            "leaderTimeunitsAllocation": "100",
+            "validatorTimeunitsAllocation": "200",
             "executionBudgetPerRound": "10",
             "totalMessageFees": "5",
         }
     }
-    assert "leaderTimeunitsAllocation" not in profile["methods"]["create_bet"]
-    assert "validatorTimeunitsAllocation" not in profile["methods"]["create_bet"]
 
 
 def test_write_creates_parent_dirs_and_round_trips_json(tmp_path):
@@ -168,6 +285,8 @@ def test_transact_records_fee_profile_observation(monkeypatch, tmp_path):
         network="localnet", headroom=1.0
     )
     assert profile["methods"]["create_bet"] == {
+        "leaderTimeunitsAllocation": "100",
+        "validatorTimeunitsAllocation": "200",
         "executionBudgetPerRound": "312500",
         "totalMessageFees": "12500",
     }
@@ -196,6 +315,8 @@ def test_deploy_records_fee_profile_observation(monkeypatch, tmp_path):
         network="localnet", headroom=1.0
     )
     assert profile["deploy"] == {
+        "leaderTimeunitsAllocation": "100",
+        "validatorTimeunitsAllocation": "200",
         "executionBudgetPerRound": "625000",
         "totalMessageFees": "0",
     }


### PR DESCRIPTION
## Summary
- record leader/validator time-unit allocation, rotations, execution budget, and message fees from current Studio fee accounting receipts
- support current GenVM contract base syntax and SDK wait receipt compatibility
- document that fee profiles are generic suggestions for transaction-kit, genlayer-js, genlayer-py, and CLI flows
- add tests for Studio fee accounting shapes and per-field maxima across multiple method branches

## Validation
- uv run --no-project --with-editable /Users/edgars/Dev/testing-suite-fee-profile --with-editable /Users/edgars/Dev/genlayer-py-v019 --with pytest python -m pytest tests/gltest/fees/test_fee_profile.py tests/gltest/contracts/test_fee_params.py tests/gltest/artifact/test_contract_definition.py -q