### PR TITLE
chore(genvm): migrate to GenVM v0.3.0-rc7 SDK APIs ⬆️

### DIFF
--- a/glsim/README.md
+++ b/glsim/README.md
@@ -145,9 +145,9 @@ Contracts that read sibling files via `open("/contract/OtherModule.py")` work �
 ### Cross-Contract Calls
 
 Contracts using `gl.contract.deploy()`, `gl.contract.get_at().view()`, and `gl.contract.get_at().emit()` work. glsim handles:
-- **DeployContract** — deploys child contract with isolated storage
+- **EmitInternalDeployMessage** — deploys child contract with isolated storage
 - **CallContract** — calls method on deployed contract, returns result
-- **PostMessage** — fire-and-forget call (no return value)
+- **EmitInternalMessage** — fire-and-forget call (no return value)
 
 ### GenVM Library Stubs
 

--- a/glsim/engine.py
+++ b/glsim/engine.py
@@ -614,16 +614,20 @@ class SimEngine:
             self.vm._live_llm_handler = self._llm_handler
 
     def install_cross_contract_hook(self) -> None:
-        """Install gl_call hook for cross-contract calls (DeployContract, CallContract, PostMessage)."""
+        """Install gl_call hook for cross-contract calls (EmitInternalDeployMessage, CallContract, EmitInternalMessage)."""
         engine = self
 
         def hook(vm, request):
-            if "DeployContract" in request:
-                return engine._handle_deploy_in_contract(vm, request["DeployContract"])
+            if "EmitInternalDeployMessage" in request:
+                return engine._handle_deploy_in_contract(
+                    vm, request["EmitInternalDeployMessage"]
+                )
             if "CallContract" in request:
                 return engine._handle_call_in_contract(vm, request["CallContract"])
-            if "PostMessage" in request:
-                return engine._handle_post_in_contract(vm, request["PostMessage"])
+            if "EmitInternalMessage" in request:
+                return engine._handle_post_in_contract(
+                    vm, request["EmitInternalMessage"]
+                )
             return None
 
         self.vm._gl_call_hook = hook

--- a/glsim/engine.py
+++ b/glsim/engine.py
@@ -614,7 +614,7 @@ class SimEngine:
             self.vm._live_llm_handler = self._llm_handler
 
     def install_cross_contract_hook(self) -> None:
-        """Install gl_call hook for cross-contract calls (EmitInternalDeployMessage, CallContract, EmitInternalMessage)."""
+        """Install gl_call hooks for current and rc7 cross-contract calls."""
         engine = self
 
         def hook(vm, request):
@@ -622,12 +622,16 @@ class SimEngine:
                 return engine._handle_deploy_in_contract(
                     vm, request["EmitInternalDeployMessage"]
                 )
+            if "DeployContract" in request:
+                return engine._handle_deploy_in_contract(vm, request["DeployContract"])
             if "CallContract" in request:
                 return engine._handle_call_in_contract(vm, request["CallContract"])
             if "EmitInternalMessage" in request:
                 return engine._handle_post_in_contract(
                     vm, request["EmitInternalMessage"]
                 )
+            if "PostMessage" in request:
+                return engine._handle_post_in_contract(vm, request["PostMessage"])
             return None
 
         self.vm._gl_call_hook = hook

--- a/gltest/direct/sdk_loader.py
+++ b/gltest/direct/sdk_loader.py
@@ -11,6 +11,7 @@ import sys
 import json
 import shutil
 import tarfile
+import zipfile
 import platform
 import tempfile
 import urllib.error
@@ -41,6 +42,9 @@ RUNNER_BUNDLE_ASSETS = (
 )
 GENVM_VERSION_ENV = "GENVM_VERSION"
 FALLBACK_VERSION = "v0.6.0-rc0"
+
+# v0.3 runner trees use .zip; the v0.2 legacy-runners tree uses .tar.
+RUNNER_ARCHIVE_EXTS = (".tar", ".zip")
 
 RUNNER_TYPE = "py-genlayer"
 STD_LIB_TYPE = "py-lib-genlayer-std"
@@ -179,21 +183,33 @@ def _extract_local_runner(
     root: Path, runner_type: str, runner_hash: Optional[str]
 ) -> Path:
     """Extract a runner from a local prebuilt GenVM tree (GENVM_PREBUILT_DIR); globs
-    any *runners* dir so runners/ and executor/<ver>/legacy-runners/ both match."""
+    any *runners* dir so runners/ and executor/<ver>/legacy-runners/ both match.
+    v0.3 runners ship as .zip, the v0.2 legacy tree still ships .tar."""
     sub = (
-        f"{runner_hash[:2]}/{runner_hash[2:]}.tar"
+        f"{runner_hash[:2]}/{runner_hash[2:]}"
         if runner_hash and runner_hash.lower() != "latest"
-        else "*/*.tar"
+        else "*/*"
     )
-    hits = sorted(root.glob(f"**/*runners*/{runner_type}/{sub}"))
+    hits = sorted(
+        hit
+        for ext in RUNNER_ARCHIVE_EXTS
+        for hit in root.glob(f"**/*runners*/{runner_type}/{sub}{ext}")
+    )
     if not hits:
         raise FileNotFoundError(f"runner {runner_type}:{runner_hash} not under {root}")
-    tar = hits[-1]
-    dest = CACHE_DIR / "extracted" / "local" / runner_type / (tar.parent.name + tar.stem)
+    archive = hits[-1]
+    dest = (
+        CACHE_DIR / "extracted" / "local" / runner_type
+        / (archive.parent.name + archive.stem)
+    )
     if not dest.exists():
         dest.mkdir(parents=True, exist_ok=True)
-        with tarfile.open(tar, "r:") as inner:
-            inner.extractall(dest, filter="data")
+        if archive.suffix == ".zip":
+            with zipfile.ZipFile(archive) as inner:
+                inner.extractall(dest)
+        else:
+            with tarfile.open(archive, "r:") as inner:
+                inner.extractall(dest, filter="data")
     return dest
 
 

--- a/gltest/direct/vm.py
+++ b/gltest/direct/vm.py
@@ -202,7 +202,7 @@ class VMContext:
     _live_web_handler: Optional[Any] = None
     _live_llm_handler: Optional[Any] = None
 
-    # Cross-contract call hook (for glsim — handles EmitInternalDeployMessage/CallContract/EmitInternalMessage)
+    # Cross-contract call hook (glsim accepts current and rc7 request names).
     _gl_call_hook: Optional[Any] = None
 
     # Debug tracing

--- a/gltest/direct/vm.py
+++ b/gltest/direct/vm.py
@@ -202,7 +202,7 @@ class VMContext:
     _live_web_handler: Optional[Any] = None
     _live_llm_handler: Optional[Any] = None
 
-    # Cross-contract call hook (for glsim — handles DeployContract/CallContract/PostMessage)
+    # Cross-contract call hook (for glsim — handles EmitInternalDeployMessage/CallContract/EmitInternalMessage)
     _gl_call_hook: Optional[Any] = None
 
     # Debug tracing

--- a/gltest/direct/wasi_mock.py
+++ b/gltest/direct/wasi_mock.py
@@ -85,7 +85,13 @@ def get_self_balance() -> int:
 
 
 _CROSS_CONTRACT_OPS = frozenset(
-    {"EmitInternalDeployMessage", "CallContract", "EmitInternalMessage"}
+    {
+        "DeployContract",
+        "EmitInternalDeployMessage",
+        "CallContract",
+        "PostMessage",
+        "EmitInternalMessage",
+    }
 )
 
 

--- a/gltest/direct/wasi_mock.py
+++ b/gltest/direct/wasi_mock.py
@@ -84,7 +84,9 @@ def get_self_balance() -> int:
     return vm._balances.get(addr_bytes, 0)
 
 
-_CROSS_CONTRACT_OPS = frozenset({"DeployContract", "CallContract", "PostMessage"})
+_CROSS_CONTRACT_OPS = frozenset(
+    {"EmitInternalDeployMessage", "CallContract", "EmitInternalMessage"}
+)
 
 
 def gl_call(data: bytes, /) -> int:

--- a/tests/examples/contracts/intelligent_oracle_factory.py
+++ b/tests/examples/contracts/intelligent_oracle_factory.py
@@ -38,7 +38,7 @@ class Registry(gl.contract.Contract):
                 earliest_resolution_date,
             ],
             salt_nonce=registered_contracts + 1,
-            on="accepted",
+            on="decided",
         )
         print("contract_address", contract_address)
         print("contract_address type", type(contract_address))

--- a/tests/examples/contracts/log_indexer.py
+++ b/tests/examples/contracts/log_indexer.py
@@ -23,7 +23,9 @@ class StoreValue:
 
 # contract class
 class LogIndexer(gl.contract.Contract):
-    vector_store: gle.VecDB[np.float32, typing.Literal[384], StoreValue]
+    vector_store: gle.VecDB[
+        np.float32, typing.Literal[384], StoreValue, gle.EuclideanDistance
+    ]
 
     def __init__(self):
         pass

--- a/tests/examples/contracts/multi_file_contract/__init__.py
+++ b/tests/examples/contracts/multi_file_contract/__init__.py
@@ -12,7 +12,7 @@ class MultiFileContract(gl.contract.Contract):
             args=["123"],
             salt_nonce=1,
             value=0,
-            on="accepted",
+            on="decided",
         )
 
     @gl.public.write

--- a/tests/examples/contracts/multi_tenant_storage.py
+++ b/tests/examples/contracts/multi_tenant_storage.py
@@ -46,6 +46,6 @@ class MultiTentantStorage(gl.contract.Contract):
             self.available_storage_contracts.pop()
 
         contract_to_use = self.mappings[gl.message.sender_address]
-        gl.contract.get_at(contract_to_use).emit(on="accepted").update_storage(
+        gl.contract.get_at(contract_to_use).emit(on="decided").update_storage(
             new_storage
         )

--- a/tests/glsim/deterministic_factory_contract.py
+++ b/tests/glsim/deterministic_factory_contract.py
@@ -25,7 +25,7 @@ class DeterministicFactory(gl.contract.Contract):
             args=[],
             kwargs={},
             salt_nonce=salt,
-            on="accepted",
+            on="decided",
         )
         self.child_address = child_address.as_hex
         return self.child_address

--- a/tests/gltest_direct/test_direct_runner.py
+++ b/tests/gltest_direct/test_direct_runner.py
@@ -250,7 +250,8 @@ class TestNondetRestrictions:
     """Tests that cross-contract calls are forbidden inside nondet context.
 
     GenVM raises SystemError: 6 (forbidden) when contract code attempts
-    cross-contract calls (DeployContract, CallContract, PostMessage) inside
+    cross-contract calls (EmitInternalDeployMessage, CallContract,
+    EmitInternalMessage) inside
     eq_principle/run_nondet. These tests verify gltest enforces the same
     restriction in direct mode.
     """
@@ -278,7 +279,7 @@ class TestNondetRestrictions:
             gl_vm.run_nondet(bad_leader, lambda r: True)
 
     def test_deploy_contract_forbidden_in_nondet(self, direct_vm, direct_deploy):
-        """DeployContract inside run_nondet raises RuntimeError."""
+        """EmitInternalDeployMessage inside run_nondet raises RuntimeError."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
         import genlayer.vm as gl_vm
@@ -286,7 +287,7 @@ class TestNondetRestrictions:
         from gltest.direct import wasi_mock
 
         def bad_leader():
-            request = {"DeployContract": {"code": b"pass", "calldata": {}}}
+            request = {"EmitInternalDeployMessage": {"code": b"pass", "calldata": {}}}
             wasi_mock.gl_call(calldata.encode(request))
             return "should not reach"
 
@@ -294,7 +295,7 @@ class TestNondetRestrictions:
             gl_vm.run_nondet(bad_leader, lambda r: True)
 
     def test_post_message_forbidden_in_nondet(self, direct_vm, direct_deploy):
-        """PostMessage inside run_nondet raises RuntimeError."""
+        """EmitInternalMessage inside run_nondet raises RuntimeError."""
         direct_deploy(str(CONTRACTS_DIR / "storage.py"), "v")
 
         import genlayer.vm as gl_vm
@@ -303,7 +304,7 @@ class TestNondetRestrictions:
 
         def bad_leader():
             request = {
-                "PostMessage": {
+                "EmitInternalMessage": {
                     "address": b"\x00" * 20,
                     "calldata": {"method": "bar", "args": []},
                 }


### PR DESCRIPTION
## Description

Migrates gltest to the GenVM v0.3.0-rc7 SDK. **No runner-hash bump** — this repo pins zero hashes, every fixture uses `py-genlayer:latest`.

1. `on="accepted"` → `on="decided"` in 4 contract fixtures
2. `gltest/direct/sdk_loader.py` reads both `.zip` and `.tar` runner archives — upstream changed the built tree from `<id>/<aa>/<rest>.tar` to `.zip`, while the v0.2 `legacy-runners/` tree stays `.tar` and both are resolved by the same glob
3. glsim/direct-mode adapters accept both the released SDK's `DeployContract` / `PostMessage` request names and rc7's `EmitInternalDeployMessage` / `EmitInternalMessage`, keeping native CI compatible while the multi-repo cut lands

Upstream: genvm-manager #24.

Depends-On: genlayerlabs/genvm-manager#24

## Motivation and Context

Direct mode extracts runners straight out of the GenVM tree, so the archive-format change breaks it outright. The `on=` rename has no back-compat alias.

## How Has This Been Tested?

Python 3.13 native-CI environment (`uv sync --extra sim`):

- deterministic deploy regression: passed
- full `tests/glsim` suite: **72 passed**

Extraction logic additionally verified standalone against a synthetic tree: zip-by-hash, tar-by-hash and `latest` all resolve, and path-sort preference still puts `runners/` (v0.3) ahead of `legacy-runners/` for `:latest`.

## Decisions Made

- `gltest/assertions.py` `ACCEPTED_STATUSES` / `_has_accepted_status` is a consensus **transaction status**, not the SDK `on=` value — untouched. `gltest/contracts/*` already spoke `decided` / `finalized`
- `.tar.xz` names in `sdk_loader.py` are genvm-manager *release bundles*, a different artifact from runner archives — untouched

## Risks

The `.zip` path uses `ZipFile.extractall` with no equivalent of tar's `filter="data"` (stdlib offers none). Inputs are our own release artifacts, the same trust level as the existing tar path, but it is a slightly weaker guard against crafted entry names.

## Changeset

| Repo | PR | Base |
|---|---|---|
| genvm-manager | genlayerlabs/genvm-manager#24 | `v0.6-dev` |
| genlayer-node | genlayerlabs/genlayer-node#1753 | `v0.6-dev` |
| genlayer-studio | genlayerlabs/genlayer-studio#1744 | `v0.123-dev` |
| genlayer-py | genlayerlabs/genlayer-py#105 | `v0.19-dev` |
| genlayer-testing-suite | genlayerlabs/genlayer-testing-suite#106 | `v0.30-dev` |
| genlayer-e2e | genlayerlabs/genlayer-e2e#723 | `main` |
| genlayer-dev-env | genlayerlabs/genlayer-dev-env#130 | `main` |

No PR for **genlayer-js** or **genlayer-consensus** — neither needed a change.
